### PR TITLE
Progress bar

### DIFF
--- a/opcoes/opcoes.html
+++ b/opcoes/opcoes.html
@@ -55,6 +55,11 @@
             <input type="checkbox" id="autoFixarMenuLobby" />
             <span class="checkmark"></span>
           </label>
+          <label class="container" for="autoMostrarLevelProgress" title="Mostra seu Level, Rating atual, e quantos pontos é preciso para chegar ao proximo Level.">
+            <p class="descricao">Mostrar seu progresso no menu</p>
+            <input type="checkbox" id="autoMostrarLevelProgress" />
+            <span class="checkmark"></span>
+          </label>
         </div>
 
         <div class="pagina" id="lobby">Em breve teremos opções para criação de lobby.</div>

--- a/opcoes/opcoes.js
+++ b/opcoes/opcoes.js
@@ -4,6 +4,7 @@ const features = [
     'autoAceitarReady',
     'autoFixarMenuLobby',
     'autoConcordarTermosRanked',
+    'autoMostrarLevelProgress',
 ];
 const paginas = ['geral', 'mapas', 'lobby', 'contato', 'sobre'];
 

--- a/pages/geral/index.js
+++ b/pages/geral/index.js
@@ -1,18 +1,90 @@
-const log = (msg) => console.log('[GC Booster] ', msg);
+const log = (msg) => console.log('[GC Booster]', msg);
 
 let generalOptions = [];
-chrome.storage.sync.get(null, function (result) {
+chrome.storage.sync.get(['autoMostrarLevelProgress'], function (result) {
     generalOptions = result;
     initGcBooster();
 });
 
+const levelRatingXP = [1000, 1056, 1116, 1179, 1246, 1316, 1390, 1469, 1552, 1639, 1732, 1830, 1933, 2042, 2158, 2280, 2408, 2544, 2688, 2840, 2999];
+const levelColor = ['#000', '#643284', '#5c2d84', '#532883', '#492381', '#402686', '#2d3a8a', '#2967b0', '#2967b0', '#2a7bc2', '#2a8acc', '#3e9cb7', '#53a18b', '#68a761', '#7cac35', '#91b20a', '#bdb700', '#f0bc00', '#f89a06', '#f46e12', '#eb2f2f'];
+
+function XpRangeFromLevel(level) {
+    return {
+        minRating: levelRatingXP[level - 1],
+        maxRating: levelRatingXP[level]
+    }
+}
+
+// Um helper para pegar a var necessaria.
+function retrieveWindowVariables(variables) {
+    var ret = {};
+
+    var scriptContent = "";
+    for (var i = 0; i < variables.length; i++) {
+        var currVariable = variables[i];
+        scriptContent += "if (typeof " + currVariable + " !== 'undefined') $('body').attr('tmp_" + currVariable + "', " + currVariable + ");\n"
+    }
+
+    var script = document.createElement('script');
+    script.id = 'tmpScript';
+    script.appendChild(document.createTextNode(scriptContent));
+    (document.body || document.head || document.documentElement).appendChild(script);
+
+    for (var i = 0; i < variables.length; i++) {
+        var currVariable = variables[i];
+        ret[currVariable] = $("body").attr("tmp_" + currVariable);
+        $("body").removeAttr("tmp_" + currVariable);
+    }
+
+    $("#tmpScript").remove();
+
+    return ret;
+}
+
 const initGcBooster = async () => {
-    if ($('#GamersClubStatsBox').is(':visible')) {
-        const minPontos = $('.StatsBoxProgressBar__minRating').text();
-        const maxPontos = $('.StatsBoxProgressBar__maxRating').text();
-        const atualPontos = $('.StatsBoxRating__Score').text();
-        const pontosSubir = maxPontos - atualPontos;
-        const pontosCair = minPontos - atualPontos;
-        $('.StatsBoxRating__Header').append(`<span style="font-size:10px">${pontosCair} / ${pontosSubir}</span>`);
+    if ( generalOptions.autoMostrarLevelProgress ) {
+        var windowVariables = retrieveWindowVariables(["PLAYERID"]);
+        const PlayerID = windowVariables.PLAYERID;      //$(`#GamersClubStatsBox`).attr( "data-prop-player-id" ); oldmetd
+        $.get( "https://gamersclub.com.br/api/box/init/" + parseInt(PlayerID) ).done( function( data ) {
+            const playerName = data.playerInfo.nick;
+            const playerLevel = data.playerInfo.level;
+            const currentRating = data.playerInfo.rating;
+
+            const minPontos = XpRangeFromLevel(playerLevel).minRating;
+            const maxPontos = XpRangeFromLevel(playerLevel).maxRating;
+
+            const pontosCair = minPontos - currentRating;
+            const pontosSubir = maxPontos - currentRating;
+
+            const playerNextLevel = playerLevel == 20 ? "20" : playerLevel + 1;
+            const progressBar = maxPontos ? `${((currentRating - minPontos) / (maxPontos - minPontos)) * 100}%` : '100%';
+
+            var fixedNum = parseFloat(progressBar).toFixed(4);
+
+            $('.MainHeader__navbarBlock:last').before(`<div style="display: flex;align-items: center;margin-right: 24px;margin-left: 24px;">
+                <span title="Skill Level ${playerLevel}" style="display: inline-block;" data-tip-text="Skill Level ${playerLevel}">
+                <div class="PlayerLevel PlayerLevel--${playerLevel} PlayerLevel--nonSubscriber" style="height: 28px; width: 28px; font-size: 12px;"><div class="PlayerLevel__background"><span class="PlayerLevel__text">${playerLevel}</span></div></div>
+                </span>
+                <div style="margin-right: 4px;margin-left: 4px;">
+                    <div class="text-light" style="display: flex; justify-content: space-between;">
+                        <a class="text-sm text-muted bold" style="align-self: flex-end;">
+                            <div>${playerName}</div>
+                        </a>
+                        <div style="display: flex; align-items: center; justify-content: flex-end;"><span style="cursor: help;" title="Rating atual">${currentRating}</span></div>
+                    </div>
+                    <div>
+                        <div style="margin: 1px 0px;height: 2px;width: 160px;background: rgb(75, 78, 78);">
+
+                            <div style="height: 100%;width:${fixedNum}%; background: linear-gradient(to right, ${levelColor[playerLevel]}, ${levelColor[playerNextLevel]});"></div>
+                        </div>
+                        <div class="text-sm text-muted bold" style="display: flex; justify-content: space-between;">${minPontos}<span><span style="cursor: help;" title="Quantidade de pontos para cair de Level">${pontosCair}</span>/<span style="cursor: help;" title="Quantidade de pontos para subir de Level">+${pontosSubir}</span></span><span>${maxPontos}</span></div>
+                    </div>
+                </div>
+                <span title="Skill Level ${playerNextLevel}" style="display: inline-block;" data-tip-text="Skill Level ${playerNextLevel}">
+                <div class="PlayerLevel PlayerLevel--${playerNextLevel} PlayerLevel--nonSubscriber" style="height: 28px; width: 28px; font-size: 12px;"><div class="PlayerLevel__background"><span class="PlayerLevel__text">${playerNextLevel}</span></div></div>
+                </span>
+            </div>`);
+        });
     }
 };

--- a/pages/geral/index.js
+++ b/pages/geral/index.js
@@ -45,7 +45,7 @@ function retrieveWindowVariables(variables) {
 const initGcBooster = async () => {
     if ( generalOptions.autoMostrarLevelProgress ) {
         var windowVariables = retrieveWindowVariables(["PLAYERID"]);
-        const PlayerID = windowVariables.PLAYERID;      //$(`#GamersClubStatsBox`).attr( "data-prop-player-id" ); oldmetd
+        const PlayerID = windowVariables.PLAYERID;      //$(`#GamersClubStatsBox`).attr( "data-prop-player-id" ); old method
         $.get( "https://gamersclub.com.br/api/box/init/" + parseInt(PlayerID) ).done( function( data ) {
             const playerName = data.playerInfo.nick;
             const playerLevel = data.playerInfo.level;
@@ -57,8 +57,11 @@ const initGcBooster = async () => {
             const pontosCair = minPontos - currentRating;
             const pontosSubir = maxPontos - currentRating;
 
-            const playerNextLevel = playerLevel == 20 ? "20" : playerLevel + 1;
+            const playerNextLevel = playerLevel == 20 ? 21 : playerLevel + 1;
             const progressBar = maxPontos ? `${((currentRating - minPontos) / (maxPontos - minPontos)) * 100}%` : '100%';
+
+            const strText = playerNextLevel == 21 ? "" : "Skill Level " + playerNextLevel;
+            const nextLvl = playerNextLevel == 21 ? "" : playerNextLevel;
 
             var fixedNum = parseFloat(progressBar).toFixed(4);
 
@@ -69,7 +72,7 @@ const initGcBooster = async () => {
                 <div style="margin-right: 4px;margin-left: 4px;">
                     <div class="text-light" style="display: flex; justify-content: space-between;">
                         <a class="text-sm text-muted bold" style="align-self: flex-end;">
-                            <div>${playerName}</div>
+                            <div style="overflow: hidden;text-overflow: ellipsis;width: 70%;">${playerName}</div>
                         </a>
                         <div style="display: flex; align-items: center; justify-content: flex-end;"><span style="cursor: help;" title="Rating atual">${currentRating}</span></div>
                     </div>
@@ -81,8 +84,8 @@ const initGcBooster = async () => {
                         <div class="text-sm text-muted bold" style="display: flex; justify-content: space-between;">${minPontos}<span><span style="cursor: help;" title="Quantidade de pontos para cair de Level">${pontosCair}</span>/<span style="cursor: help;" title="Quantidade de pontos para subir de Level">+${pontosSubir}</span></span><span>${maxPontos}</span></div>
                     </div>
                 </div>
-                <span title="Skill Level ${playerNextLevel}" style="display: inline-block;" data-tip-text="Skill Level ${playerNextLevel}">
-                <div class="PlayerLevel PlayerLevel--${playerNextLevel} PlayerLevel--nonSubscriber" style="height: 28px; width: 28px; font-size: 12px;"><div class="PlayerLevel__background"><span class="PlayerLevel__text">${playerNextLevel}</span></div></div>
+                <span title="${strText}" style="display: inline-block;">
+                <div class="PlayerLevel PlayerLevel--${playerNextLevel} PlayerLevel--nonSubscriber" style="height: 28px; width: 28px; font-size: 12px;"><div class="PlayerLevel__background"><span class="PlayerLevel__text">${nextLvl}</span></div></div>
                 </span>
             </div>`);
         });


### PR DESCRIPTION
Adicionei esse level progress para ficar fácil a visualização de quantos pontos são necessários para subir ou cair do nível atual.
Tem tooltip nos itens mais importantes

tentei fazer usando o $('#GamersClubStatsBox').is(':visible') mas como não tem em todas as paginas peguei pela ID do jogador.

Se preciso muda os textos, não sabia muito bem o que escrevia no menu da extensão.

Antes
![image](https://user-images.githubusercontent.com/48375198/113122574-27245780-91ea-11eb-93f5-718c4bf93a6a.png)

LVL 20
![image](https://user-images.githubusercontent.com/48375198/113127202-dc590e80-91ee-11eb-8c1b-d1e55291827e.png)

LVL 1-19
![image](https://user-images.githubusercontent.com/48375198/113127514-34901080-91ef-11eb-93cb-2a8c9bd33efa.png)


*Não retirei o outro*

