### PR TITLE
feat: ajusta posicao e comportamento do lobby sidebar

### DIFF
--- a/src/content-scripts/lobby/autoFixarMenuLobby.js
+++ b/src/content-scripts/lobby/autoFixarMenuLobby.js
@@ -12,32 +12,30 @@ export const autoFixarMenuLobby = mutations =>
           const node = mutation.addedNodes[i];
           if ( typeof node.id !== 'undefined' ) {
             if ( node.id.includes( 'SidebarSala' ) ) {
-              if ( !isSubscriber ) {
-                $( node ).css( {
-                  position: 'fixed',
-                  top: '130px',
-                  bottom: 'auto'
-                } );
-              } else {
-                $( node ).css( {
-                  position: 'fixed',
-                  top: '10%',
-                  bottom: 'auto'
-                } );
-              }
+              $ ( node ).css( {
+                'position': 'absolute',
+                'left': '0',
+                'top': '33px',
+                'width': '227px',
+                'border-radius': '0 6px 6px 0',
+                'background': '#2c2d3d',
+                'z-index': '4',
+                'paddin': '12px 8px',
+                'bottom': 'auto'
+              } );
             }
             if ( node.className.includes( 'sidebar-desafios sidebar-content' ) ) {
               if ( !isSubscriber ) {
                 $( node ).css( {
                   position: 'fixed',
-                  top: '130px',
+                  top: '22%',
                   right: '72px',
                   bottom: 'auto'
                 } );
               } else {
                 $( node ).css( {
                   position: 'fixed',
-                  top: '10%',
+                  top: '20%',
                   right: '72px',
                   bottom: 'auto'
                 } );


### PR DESCRIPTION
Ajusta o posicionamento do menu de lobby e de desafios para ficar melhor com a nova interface da plataforma.

Foi escolhido manter o menu da sala do lobby fixa na página (sem acompanhar o scroll), pois a sidebar está muito grande, e fica sobrepondo com o menu de suporte. Ainda é um comportamento melhor do que ficar teletransportando com o scroll, pois permite o usuário clicar nos botões sem medo de errar.

A sidebar dos desafios continua acompanhando o scroll, pois não tem nenhuma sobreposição, e é útil que acompanhe para o usuário visualizar os desafios enquanto escolhe novos cards para desafiar.