### PR TITLE
fix: correcao do KDR quando o nick tiver pipe

### DIFF
--- a/src/content-scripts/content.css
+++ b/src/content-scripts/content.css
@@ -74,3 +74,12 @@ input[type="range"].filterKdr::-ms-tooltip {
   button {
   background-color: rgba(255, 0, 0, 0.322);
 }
+/* .sala-card-wrapper {
+  width: 50% !important;
+}
+
+.sala-card-wrapper > div,
+.sala-card-wrapper .sala-card {
+  width: 100%;
+}
+ */

--- a/src/content-scripts/lobby/mostrarKdr.js
+++ b/src/content-scripts/lobby/mostrarKdr.js
@@ -63,7 +63,7 @@ export const mostrarKdrSala = mutations =>
       const node = mutation.addedNodes[i];
       if ( node.className && ( node.className.includes( 'sidebar-item' ) || node.className.includes( 'sidebar-sala-players' ) ) ) {
         const selectorLink = node.querySelector( 'a' );
-        const kdr = selectorLink.getAttribute( 'title' ).split( ' | ' )[1];
+        const kdr = selectorLink.getAttribute( 'title' ).split( '|' ).find( str => str.includes( 'KDR:' ) ).trim();
         const searchKdr = kdr.split( ' ' )[1];
 
         const colorKrdDefault = searchKdr <= 2 ? '#000' :


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5823077/174939928-f100c5bb-520c-4a37-95a3-1793819a3c6a.png)

Agora faço a busca pelo KDR: ,

Exemplo de teste: 

"RFS | 82 |  KDR: 0.86 | Prime".split('|').find(str => str.includes("KDR:")).trim().split(' ')[1];