### PR TITLE
[Sugestão] fix: reposiciona barra de level na parte superior da tela

### DIFF
--- a/src/content-scripts/content.css
+++ b/src/content-scripts/content.css
@@ -215,13 +215,13 @@ input[type="range"].filterKdr::-ms-tooltip {
 }
 .bar-level {
   position: fixed;
-  bottom: 0;
+  top: 0;
   left: 0;
   z-index: 999;
   display: flex;
   align-items: center;
   font-size: 11px;
-  padding: 8px;
+  padding: 4px;
   left: 50%;
 
   -webkit-transform: translatex(-50%);
@@ -229,10 +229,10 @@ input[type="range"].filterKdr::-ms-tooltip {
   transform: translatex(-50%);
 
   box-shadow: inset 0px -1px 9px 6px rgb(255 141 0 / 10%), 0 0 14px #00000073;
-  border-radius: 8px 8px 0 0;
+  border-radius: 0 0 8px 8px;
   background: rgb(0 0 0);
   border: 1px solid orange;
-  border-bottom: 0;
+  border-top: 0;
 }
 
 .bar-info-player {


### PR DESCRIPTION
Como sugestão, coloquei a barra de level para parte superior da tela, pois estava atrapalhando o novo chat da plataforma.