### PR TITLE
update: Lista de mapas pré veto

### DIFF
--- a/src/lib/maps.js
+++ b/src/lib/maps.js
@@ -38,7 +38,7 @@ export function getMapImage( map ) {
 
   case 'de_cache_old':
     return 'https://steamuserimages-a.akamaihd.net/ugc/1822269383661548991/2C886B2A6EAB6E266B5E84BB1039E701205A48C1/';
-  
+
   default:
     return '';
   }

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -349,6 +349,7 @@
               <span class="checkmark"></span>
             </label>
           </div>
+          
           <div class="column">
             <label class="container" for="preVetode_inferno">
               <p class="descricao">de_inferno</p>
@@ -361,11 +362,13 @@
               <input type="checkbox" id="preVetode_vertigo" codigo="10" />
               <span class="checkmark"></span>
             </label>
-            <label class="container" for="preVetode_cbble_classic">
+            
+            <!-- <label class="container" for="preVetode_cbble_classic">
               <p class="descricao">de_cbble_classic</p>
               <input type="checkbox" id="preVetode_cbble_classic" codigo="11" />
               <span class="checkmark"></span>
-            </label>
+            </label> -->
+            
             <label class="container" for="preVetode_ancient">
               <p class="descricao">de_ancient</p>
               <input type="checkbox" id="preVetode_ancient" codigo="12" />

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -64,6 +64,8 @@ function limparOpcoesInvalidas() {
     if ( res.preVetos && res.preVetos.length > 0 ) {
       // train
       limparPreVetos( res.preVetos, 3 );
+      // cbble_classic 
+      limparPreVetos( res.preVetos, 11 );
       // tuscan
       limparPreVetos( res.preVetos, 13 );
     }

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -64,7 +64,7 @@ function limparOpcoesInvalidas() {
     if ( res.preVetos && res.preVetos.length > 0 ) {
       // train
       limparPreVetos( res.preVetos, 3 );
-      // cbble_classic 
+      // cbble_classic
       limparPreVetos( res.preVetos, 11 );
       // tuscan
       limparPreVetos( res.preVetos, 13 );


### PR DESCRIPTION
Acredito que podemos remover mapa de_cbble_classic, ele não esta mais na rotação da GC.

![image](https://user-images.githubusercontent.com/32937653/226447530-308b9599-c4a3-433d-b54a-d3a7375ee24f.png)