### PR TITLE
Replace de_cache_old with de_train

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -69,10 +69,10 @@ export const preVetosMapas = [
     mapa: 'de_nuke',
     codigo: 2
   },
-  // {
-  //   mapa: 'de_train',
-  //   codigo: 3
-  // },
+  {
+    mapa: 'de_train',
+    codigo: 3
+  },
   {
     mapa: 'de_mirage',
     codigo: 5
@@ -104,11 +104,11 @@ export const preVetosMapas = [
   {
     mapa: 'de_anubis',
     codigo: 14
-  },
-  {
-    mapa: 'de_cache_old',
-    codigo: 16
   }
+  // {
+  //   mapa: 'de_cache_old',
+  //   codigo: 16
+  // }
 ];
 export const configValues = [ 'somReady', 'volume', 'customSomReady' ];
 export const paginas = [ 'novidades', 'geral', 'mapas', 'lobby', 'complete', 'contato', 'sobre', 'sons', 'integracoes', 'blocklist',

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -386,11 +386,11 @@
               <span class="checkmark"></span>
             </label>
 
-            <!-- <label class="container" for="preVetode_train">
+            <label class="container" for="preVetode_train">
               <p class="descricao">de_train</p>
               <input type="checkbox" id="preVetode_train" codigo="3" />
               <span class="checkmark"></span>
-            </label> -->
+            </label>
 
             <label class="container" for="preVetode_mirage">
               <p class="descricao">de_mirage</p>
@@ -448,11 +448,11 @@
               <span class="checkmark"></span>
             </label>
 
-            <label class="container" for="preVetode_cache_old">
+            <!-- <label class="container" for="preVetode_cache_old">
               <p class="descricao">de_cache_old</p>
               <input type="checkbox" id="preVetode_cache_old" codigo="16" />
               <span class="checkmark"></span>
-            </label>
+            </label> -->
           </div>
         </div>
       </div>
@@ -503,11 +503,11 @@
               <span class="checkmark"></span>
             </label>
 
-            <!-- <label class="container" for="complete_train">
+            <label class="container" for="completede_train">
               <p class="descricao">de_train</p>
-              <input type="checkbox" id="complete_train" codigo="3" />
+              <input type="checkbox" id="completede_train" codigo="3" />
               <span class="checkmark"></span>
-            </label> -->
+            </label>
 
             <label class="container" for="completede_mirage">
               <p class="descricao">de_mirage</p>
@@ -562,11 +562,11 @@
               <span class="checkmark"></span>
             </label>
 
-            <label class="container" for="completede_cache_old">
+            <!-- <label class="container" for="completede_cache_old">
               <p class="descricao">de_cache_old</p>
               <input type="checkbox" id="completede_cache_old" codigo="16" />
               <span class="checkmark"></span>
-            </label>
+            </label> -->
           </div>
         </div>
       </div>
@@ -755,12 +755,18 @@
           <p class="descricao" translation-key="entre-no-nosso-discord"></p>
         </a>
         <br />
-        <a href="https://github.com/gamersclub-booster/gamersclub-booster/issues" target="_blank">
+        <a
+          href="https://github.com/gamersclub-booster/gamersclub-booster/issues"
+          target="_blank"
+        >
           <h3 class="subtitulo" translation-key="informe-um-bug"></h3>
           <p class="descricao" translation-key="abra-uma-issue"></p>
         </a>
         <br />
-        <a href="https://github.com/gamersclub-booster/gamersclub-booster/" target="_blank">
+        <a
+          href="https://github.com/gamersclub-booster/gamersclub-booster/"
+          target="_blank"
+        >
           <h3 class="subtitulo" translation-key="quer-contribuir"></h3>
           <p class="descricao" translation-key="estenxao-codigo-aberto"></p>
         </a>

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -63,15 +63,33 @@ function limparPreVetos( preVetos, mapa ) {
   }
 }
 
+function limparComplete( complete, mapa ) {
+  const index = complete.indexOf( mapa );
+  if ( index > -1 ) {
+    const mapas = complete;
+    mapas.splice( index, 1 );
+    chrome.storage.sync.set( { complete: mapas } );
+  }
+}
+
 function limparOpcoesInvalidas() {
+  const mapasInvalidos = [
+    11, // cbble_classic
+    13, // tuscan
+    16 // cache_old
+  ];
   chrome.storage.sync.get( [ 'preVetos' ], res => {
     if ( res.preVetos && res.preVetos.length > 0 ) {
-      // train
-      limparPreVetos( res.preVetos, 3 );
-      // cbble_classic
-      limparPreVetos( res.preVetos, 11 );
-      // tuscan
-      limparPreVetos( res.preVetos, 13 );
+      for ( const mapa of mapasInvalidos ) {
+        limparPreVetos( res.preVetos, mapa );
+      }
+    }
+  } );
+  chrome.storage.sync.get( [ 'complete' ], res => {
+    if ( res.complete && res.complete.length > 0 ) {
+      for ( const mapa of mapasInvalidos ) {
+        limparComplete( res.complete, mapa );
+      }
     }
   } );
 }
@@ -421,7 +439,7 @@ async function popularServerWebHookOptions() {
   try {
     chrome.storage.sync.get( [ 'webhookServers' ], function ( e ) {
       console.log( e.webhookServers, 'hooks' );
-      if ( e.webhookServers.length > 0 ) {
+      if ( e.webhookServers?.length > 0 ) {
         $.each( e.webhookServers, function ( i, item ) {
           console.log( item );
           $( '#serversSelect' ).append( $( '<option>', {


### PR DESCRIPTION
This PR replaces `de_cache_old` with `de_train` since the map is not available in Gamers Club anymore.

It also fixes some errors/bugs that I've found;
- Add optional chaining due to `webhookServers` being `undefined`.
- Add logic to clear invalid `complete` maps.
- Fix invalid input `id`.
