### PR TITLE
Pequenos ajustes seguindo a documentação da mozilla e do google

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -97,7 +97,6 @@
       "128": "images/icon_128.png"
     },
     "default_popup": "index.html",
-    "browser_style": true,
     "chrome_style": true
   },
   "content_security_policy": {

--- a/manifest.json
+++ b/manifest.json
@@ -86,7 +86,6 @@
       ]
     }
   ],
-  "options_page": "index.html",
   "options_ui": {
     "page": "index.html"
   },
@@ -96,8 +95,7 @@
       "48": "images/icon_48.png",
       "128": "images/icon_128.png"
     },
-    "default_popup": "index.html",
-    "chrome_style": true
+    "default_popup": "index.html"
   },
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval';object-src 'self';"

--- a/manifest.json
+++ b/manifest.json
@@ -101,5 +101,10 @@
   },
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval';object-src 'self';"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "gamersclub-booster@gamersclub-booster"
+    }
   }
 }


### PR DESCRIPTION
- Não sei se se existe algum motivo para manter o `browser_style` e `chrome_style`, mas eu dei uma lida cuidadosa na página de migração da mozilla e do chrome e parece que essas entradas não existem.
- O `options_page` parece ter sido deprecado em favor do `options_ui`.
- O gecko id parece ser necessário para publicar a extensão no firefox, mas aparece como warning ao carregar no chrome para desenvolvimento. Até onde entendi não prejudicou o funcionamento da extensão no chrome, fica apenas com o warning. Preferi manter para ser fácil debugar em ambos os navegadores.

Referências:
- https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/
- https://developer.chrome.com/docs/extensions/develop/migrate
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json
- https://developer.chrome.com/docs/extensions/reference/manifest
- Mensagens de commit possuem referências pontuais.