### PR TITLE
fix: Fix when render multiple loads on my-matches page

### DIFF
--- a/src/content-scripts/my-matches/index.js
+++ b/src/content-scripts/my-matches/index.js
@@ -105,8 +105,7 @@ const colorirPartidas = () => {
     colorirPartidas();
   } );
   $( 'body' ).on( 'click', '#myMatchesPagination button:not(.btn-active):not(.clicked)', async function ( e ) {
-    const paginationButton = $( e.target );
-    paginationButton.addClass( 'clicked' );
+    $( e.target ).addClass( 'clicked' );
     await new Promise( r => setTimeout( r, 3000 ) );
     initVerificarBans();
     colorirPartidas();

--- a/src/content-scripts/my-matches/index.js
+++ b/src/content-scripts/my-matches/index.js
@@ -104,7 +104,9 @@ const colorirPartidas = () => {
     initVerificarBans();
     colorirPartidas();
   } );
-  $( 'body' ).on( 'click', '#myMatchesPagination', async function () {
+  $( 'body' ).on( 'click', '#myMatchesPagination button:not(.btn-active):not(.clicked)', async function ( e ) {
+    const paginationButton = $( e.target );
+    paginationButton.addClass( 'clicked' );
     await new Promise( r => setTimeout( r, 3000 ) );
     initVerificarBans();
     colorirPartidas();


### PR DESCRIPTION
This bug happens when clicking on the footer line of the my-matches page

![image](https://github.com/gamersclub-booster/gamersclub-booster/assets/26715721/551c40fe-2d7e-4811-9326-59620d6d1908)

