### PR TITLE
feat: Adiciona funcionalidade para mostrar IP assim que o servidor está disponível

### DIFF
--- a/src/content-scripts/lobby/autoMostrarIp.js
+++ b/src/content-scripts/lobby/autoMostrarIp.js
@@ -1,0 +1,15 @@
+export const autoMostrarIp = () => {
+  chrome.storage.sync.get( [ 'autoMostrarIp' ], function ( result ) {
+    if ( result.autoMostrarIp ) {
+      const interval = setInterval( () => {
+        const selector = '[class*="ServerDataContainer"]' ;
+        const serverData = $.find( selector );
+
+        if ( serverData && serverData.length ) {
+          serverData[0].style.display = 'flex';
+          clearInterval( interval );
+        }
+      }, 3000 );
+    }
+  } );
+};

--- a/src/content-scripts/lobby/index.js
+++ b/src/content-scripts/lobby/index.js
@@ -15,6 +15,7 @@ import { infoChallenge, infoLobby } from './infoLobby';
 import { ocultarNotificacaoComplete } from './ocultarNotificacaoComplete';
 import { ocultarSugestaoDeLobbies } from './ocultarSugestaoDeLobbies';
 import { tocarSomSeVoceForExpulsoDaLobby } from './tocarSomSeVoceForExpulsoDaLobby';
+import { autoMostrarIp } from './autoMostrarIp';
 
 
 chrome.storage.sync.get( null, function ( _result ) {
@@ -67,6 +68,8 @@ const initLobby = async () => {
   // adicionarFiltroKdr();
   // Feature de discord na hora de copiar o ip
   partidaInfo();
+  //Feature que mostra ip assim que server é liberado
+  autoMostrarIp();
 };
 
 const criarObserver = ( seletor, exec, type ) => {

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -48,6 +48,7 @@ export const levelColor = [
 ];
 export const features = [
   'autoCopiarIp',
+  'autoMostrarIp',
   'autoAceitarReady',
   'autoFixarMenuLobby',
   'ocultarSugestaoDeLobbies',

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -223,7 +223,7 @@
           for="autoMostrarIp"
           title="Mostra o IP assim que disponível"
         >
-          <p class="descricao" translation-key="copiar-ip"></p>
+          <p class="descricao" translation-key="auto-mostrar-ip"></p>
           <input type="checkbox" id="autoMostrarIp" />
           <span class="checkmark"></span>
         </label>

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -220,20 +220,20 @@
         </label>
         <label
           class="container"
-          for="autoMostrarIp"
-          title="Mostra o IP assim que disponível"
-        >
-          <p class="descricao" translation-key="auto-mostrar-ip"></p>
-          <input type="checkbox" id="autoMostrarIp" />
-          <span class="checkmark"></span>
-        </label>
-        <label
-          class="container"
           for="autoConcordarTermosRanked"
           title="Aceita automaticamente os termos da ranked"
         >
           <p class="descricao" translation-key="aceitar-termos-da-ranked"></p>
           <input type="checkbox" id="autoConcordarTermosRanked" />
+          <span class="checkmark"></span>
+        </label>
+        <label
+        class="container"
+        for="autoMostrarIp"
+        title="Mostra o IP assim que disponível"
+        >
+          <p class="descricao" translation-key="auto-mostrar-ip"></p>
+          <input type="checkbox" id="autoMostrarIp" />
           <span class="checkmark"></span>
         </label>
         <br />

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -220,6 +220,15 @@
         </label>
         <label
           class="container"
+          for="autoMostrarIp"
+          title="Mostra o IP assim que disponível"
+        >
+          <p class="descricao" translation-key="copiar-ip"></p>
+          <input type="checkbox" id="autoMostrarIp" />
+          <span class="checkmark"></span>
+        </label>
+        <label
+          class="container"
           for="autoConcordarTermosRanked"
           title="Aceita automaticamente os termos da ranked"
         >

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -25,6 +25,7 @@
   "aceitar-pre-ready": "Accept Pre Ready",
   "aceitar-ready": "Accept Ready",
   "copiar-ip": "Copy IP",
+  "auto-mostrar-ip": "Show IP immediately",
   "aceitar-complete": "Accept Complete",
   "aceitar-termos-da-ranked": "Accept Ranked Terms",
   "dark-mode": "Dark Mode",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -25,6 +25,7 @@
   "aceitar-pre-ready": "Aceptar Pre Ready",
   "aceitar-ready": "Aceptar Ready",
   "copiar-ip": "Copiar IP",
+  "auto-mostrar-ip": "Mostrar IP inmediatamente",
   "aceitar-complete": "Aceptar Complete",
   "aceitar-termos-da-ranked": "Aceptar Terminos da la Ranked",
   "dark-mode": "Modo escuro",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -25,6 +25,7 @@
   "aceitar-pre-ready": "Accepter le pré-Prêt",
   "aceitar-ready": "Accepter le Prêt",
   "copiar-ip": "Copier l'IP",
+  "auto-mostrar-ip": "Afficher l'IP immédiatement",
   "aceitar-complete": "Accepter Compléter",
   "aceitar-termos-da-ranked": "Accepter les termes classés",
   "dark-mode": "Mode sombre",

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -25,6 +25,7 @@
   "aceitar-pre-ready": "Aceitar Pre Ready",
   "aceitar-ready": "Aceitar Ready",
   "copiar-ip": "Copiar IP",
+  "auto-mostrar-ip": "Mostrar IP imediatamente",
   "aceitar-complete": "Aceitar Complete",
   "aceitar-termos-da-ranked": "Aceitar Termos da Ranked",
   "dark-mode": "Modo escuro",


### PR DESCRIPTION
Em uma das atualizações dos lobbys, a GC passou a ocultar o IP do servidor, exibindo apenas após clicar na opção "Quero copiar o IP", que leva alguns segundos (acho que uns 15~20s) para aparecer. Esse PR adiciona uma funcionalidade que elimina essa espera e a necessidade de clicar na opção, exibindo o IP assim que o servidor está disponível. 

![Screenshot 2025-01-23 000501](https://github.com/user-attachments/assets/04ba2b3f-15d4-4155-8991-c436495c42fa)


