### PR TITLE
feat: Criação de filtro de máximo de rounds da equipe vencedora para …

### DIFF
--- a/src/content-scripts/lobby/botaoAutoComplete.js
+++ b/src/content-scripts/lobby/botaoAutoComplete.js
@@ -85,15 +85,16 @@ async function intervalerAutoComplete() {
         const scoreLosing = parseInt( $( '.LobbyComplete__requestItemScore .LobbyComplete__requestItemScoreLosing' ).eq( 0 ).text() );
         const mapCode = getMapCode( $( '.LobbyComplete__requestItemMap' ).text() );
 
-        if ( scoreWinning && scoreLosing && mapCode ) {
-          chrome.storage.sync.get( [ 'complete', 'roundsDiff', 'roundsMin' ], res => {
-            const { complete, roundsDiff, roundsMin } = res || {};
+        if ( Number.isFinite( scoreWinning ) && Number.isFinite( scoreLosing ) && mapCode ) {
+          chrome.storage.sync.get( [ 'complete', 'roundsDiff', 'roundsMin', 'roundsMax' ], res => {
+            const { complete, roundsDiff, roundsMin, roundsMax } = res || {};
 
             const isInCheckedMaps = !complete || complete.includes( mapCode );
             const hasMinRounds = ( scoreWinning + scoreLosing ) >= roundsMin;
             const isInDiff = Math.abs( scoreWinning - scoreLosing ) <= roundsDiff;
+            const hasMaxWinningRounds = scoreWinning <= roundsMax;
 
-            if ( isInCheckedMaps && hasMinRounds && isInDiff ) {
+            if ( isInCheckedMaps && hasMinRounds && isInDiff && hasMaxWinningRounds ) {
               acceptBtn.get( 0 ).click();
               $( '#completePlayerModal > div > div.buttons > button.sm-button-accept.btn.btn-success' ).get( 0 ).click();
             }

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -508,6 +508,22 @@
         <h3 style="display: inline-block; margin-right: 10px" id="rounds-diff">
           13 rounds
         </h3>
+
+        <p translation-key="complete-max-rounds"></p>
+
+        <input
+          type="range"
+          title="Rounds"
+          id="slider-rounds-max"
+          name="rounds-max"
+          min="0"
+          max="12"
+          value="12"
+        />
+        <h3 style="display: inline-block; margin-right: 10px" id="rounds-max">
+          12 rounds
+        </h3>
+
         <h3 class="subtitulo" translation-key="complete-mapas"></h3>
 
         <div class="row">

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -624,6 +624,7 @@ function marcarJogarCom() {
 
 const sliderDiff = document.getElementById( 'slider-rounds-diff' );
 const sliderMin = document.getElementById( 'slider-rounds-min' );
+const sliderMax = document.getElementById( 'slider-rounds-max' );
 
 function popularComplete() {
   chrome.storage.sync.get( [ 'roundsDiff' ], response => {
@@ -635,6 +636,11 @@ function popularComplete() {
     if ( !response.roundsMin ) { return false; }
     sliderMin.value = response.roundsMin;
     completeMinText();
+  } );
+  chrome.storage.sync.get( [ 'roundsMax' ], response => {
+    if ( !response.roundsMax ) { return false; }
+    sliderMax.value = response.roundsMax;
+    completeMaxText();
   } );
 }
 
@@ -656,6 +662,16 @@ function completeMinText() {
   const value = sliderMin.value;
   document.getElementById( 'rounds-min' ).innerHTML = value + ' rounds';
   chrome.storage.sync.set( { 'roundsMin': value } );
+}
+
+sliderMax.addEventListener( 'change', function () {
+  completeMaxText();
+} );
+
+function completeMaxText() {
+  const value = sliderMax.value;
+  document.getElementById( 'rounds-max' ).innerHTML = value + ' rounds';
+  chrome.storage.sync.set( { 'roundsMax': value } );
 }
 
 limparOpcoesInvalidas();

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -95,5 +95,6 @@
   "warmup-fim": "Warmup is over!",
   "complete-mapas": "Maps to be accepted:",
   "complete-rounds-minimos": "Minimum rounds played:",
-  "complete-max-diff": "Maximum difference between scores:"
+  "complete-max-diff": "Maximum difference between scores:",
+  "complete-max-rounds": "Maximum score of the winning team:"
 }

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -95,5 +95,6 @@
   "warmup-fim": "¡El calentamiento ha terminado!",
   "complete-mapas": "Mapas que se aceptarán:",
   "complete-rounds-minimos": "Rondas mínimas jugadas:",
-  "complete-max-diff": "Diferencia máxima entre puntuaciones:"
+  "complete-max-diff": "Diferencia máxima entre puntuaciones:",
+  "complete-max-rounds": "Puntuación máxima del equipo ganador:"
 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -95,5 +95,6 @@
   "warmup-fim": "L'échauffement est terminé!",
   "complete-mapas": "Cartes à accepter :",
   "complete-rounds-minimos": "Tours minimum joués :",
-  "complete-max-diff": "Différence maximale entre les scores :"
+  "complete-max-diff": "Différence maximale entre les scores :",
+  "complete-max-rounds": "Score maximum de l'équipe gagnante:"
 }

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -96,5 +96,6 @@
   "warmup-fim": "O warmup chegou ao fim!",
   "complete-mapas": "Mapas a serem aceitos:",
   "complete-rounds-minimos": "Rounds mínimos jogados:",
-  "complete-max-diff": "Diferença máxima entre placares:"
+  "complete-max-diff": "Diferença máxima entre placares:",
+  "complete-max-rounds": "Placar máximo da equipe vencedora:"
 }


### PR DESCRIPTION
- Criação de filtro de máximo de rounds da equipe vencedora para função de auto-aceitar complete.
- Alteração de validação de scoreWinning e scoreLosing para Number.IsFinite. (Antigamente, caso o jogo estivesse por exemplo, 6 a 0, não passaria na validação pois 0 = false.
- Principal motivação para a criação do filtro foi para evitar entrar em partidas 12 a 10. A ideia é poder escolher um numero de 0 a 12, onde o valor é o filtro do placar máximo da equipe vencedora.