### PR TITLE
Feature/auto kick negativados

### DIFF
--- a/src/content-scripts/lobby/autoKickNegativados.js
+++ b/src/content-scripts/lobby/autoKickNegativados.js
@@ -1,0 +1,40 @@
+import axios from 'axios';
+import { GC_URL } from '../../lib/constants';
+
+export const autoKickNegativados = () =>
+  chrome.storage.sync.get( [ 'autoKickNegativados' ], function ( result ) {
+    if ( result.autoKickNegativados ) {
+      setInterval( () => {
+        $( '.LobbyPlayerHorizontal' ).each( ( index, player ) => {
+          if ( index === 0 ) { return; } // Ignora o primeiro player (você mesmo)
+
+          const $player = $( player );
+
+          // Verifica se possui anotação positiva
+          const hasPositiveNote = $player.find( '.PlayerAnnotations--negative' ).length > 0;
+
+          if ( hasPositiveNote ) {
+            // Pega o id do wrapper que contém o número do jogador
+            const idWrapper = $player.find( '[id^="player-trigger-wrapper-"]' ).attr( 'id' );
+
+            const match = idWrapper.match( /player-trigger-wrapper-(\d+)/ );
+            if ( match && match[1] ) {
+              const playerId = match[1];
+              const formData = new FormData();
+              formData.append( 'idplayer', playerId );
+
+              axios.post( `https://${GC_URL}/lobbyBeta/kickFromRoom`, formData )
+                .then( response => {
+                  console.log( `Player ${playerId} kickado com sucesso`, response.data );
+                } )
+                .catch( error => {
+                  console.error( `Erro ao kickar player ${playerId}:`, error );
+                } );
+            }
+          }
+        } );
+      }, 1500 );
+
+    }
+  } );
+

--- a/src/content-scripts/lobby/autoKickNegativados.js
+++ b/src/content-scripts/lobby/autoKickNegativados.js
@@ -10,10 +10,10 @@ export const autoKickNegativados = () =>
 
           const $player = $( player );
 
-          // Verifica se possui anotação positiva
-          const hasPositiveNote = $player.find( '.PlayerAnnotations--negative' ).length > 0;
+          // Verifica se possui anotação negativa
+          const hasNegativeNote = $player.find( '.PlayerAnnotations--negative' ).length > 0;
 
-          if ( hasPositiveNote ) {
+          if ( hasNegativeNote ) {
             // Pega o id do wrapper que contém o número do jogador
             const idWrapper = $player.find( '[id^="player-trigger-wrapper-"]' ).attr( 'id' );
 
@@ -23,7 +23,9 @@ export const autoKickNegativados = () =>
               const formData = new FormData();
               formData.append( 'idplayer', playerId );
 
-              axios.post( `https://${GC_URL}/lobbyBeta/kickFromRoom`, formData )
+              axios.post( `https://${GC_URL}/lobbyBeta/kickFromRoom`, formData, {
+                withCredentials: true
+              } )
                 .then( response => {
                   console.log( `Player ${playerId} kickado com sucesso`, response.data );
                 } )

--- a/src/content-scripts/lobby/index.js
+++ b/src/content-scripts/lobby/index.js
@@ -16,7 +16,7 @@ import { ocultarNotificacaoComplete } from './ocultarNotificacaoComplete';
 import { ocultarSugestaoDeLobbies } from './ocultarSugestaoDeLobbies';
 import { tocarSomSeVoceForExpulsoDaLobby } from './tocarSomSeVoceForExpulsoDaLobby';
 import { autoMostrarIp } from './autoMostrarIp';
-
+import { autoKickNegativados } from './autoKickNegativados';
 
 chrome.storage.sync.get( null, function ( _result ) {
   if ( window.location.pathname.includes( 'partida' ) || window.location.pathname.includes( '/match/' ) ) {
@@ -70,6 +70,8 @@ const initLobby = async () => {
   partidaInfo();
   //Feature que mostra ip assim que server é liberado
   autoMostrarIp();
+  // Feature para auto remover negativados
+  autoKickNegativados();
 };
 
 const criarObserver = ( seletor, exec, type ) => {

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -60,7 +60,8 @@ export const features = [
   'warmupTimer',
   'enviarLinkLobby',
   'enviarPartida',
-  'lobbyPrivada'
+  'lobbyPrivada',
+  'autoKickNegativados'
 ];
 export const preVetosMapas = [
   {

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -236,6 +236,11 @@
           <input type="checkbox" id="autoMostrarIp" />
           <span class="checkmark"></span>
         </label>
+        <label class="container" for="autoKickNegativados" title="Auto remover jogadores com anotação negativa">
+          <p class="descricao" translation-key="auto-kick-negativados"></p>
+          <input type="checkbox" id="autoKickNegativados" />
+          <span class="checkmark"></span>
+        </label>
         <br />
         <h3 class="subtitulo" translation-key="melhorias"></h3>
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -95,5 +95,6 @@
   "warmup-fim": "Warmup is over!",
   "complete-mapas": "Maps to be accepted:",
   "complete-rounds-minimos": "Minimum rounds played:",
-  "complete-max-diff": "Maximum difference between scores:"
+  "complete-max-diff": "Maximum difference between scores:",
+  "auto-kick-negativados": "Remove players with negative record"
 }

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -95,5 +95,6 @@
   "warmup-fim": "¡El calentamiento ha terminado!",
   "complete-mapas": "Mapas que se aceptarán:",
   "complete-rounds-minimos": "Rondas mínimas jugadas:",
-  "complete-max-diff": "Diferencia máxima entre puntuaciones:"
+  "complete-max-diff": "Diferencia máxima entre puntuaciones:",
+  "auto-kick-negativados": "Eliminar los jugadores con anotación negativa"
 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -95,5 +95,6 @@
   "warmup-fim": "L'échauffement est terminé!",
   "complete-mapas": "Cartes à accepter :",
   "complete-rounds-minimos": "Tours minimum joués :",
-  "complete-max-diff": "Différence maximale entre les scores :"
+  "complete-max-diff": "Différence maximale entre les scores :",
+  "auto-kick-negativados": "Supprimer joueurs avec une annotation négative"
 }

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -96,5 +96,6 @@
   "warmup-fim": "O warmup chegou ao fim!",
   "complete-mapas": "Mapas a serem aceitos:",
   "complete-rounds-minimos": "Rounds mínimos jogados:",
-  "complete-max-diff": "Diferença máxima entre placares:"
+  "complete-max-diff": "Diferença máxima entre placares:",
+  "auto-kick-negativados": "Remover jogadores com anotação negativa"
 }


### PR DESCRIPTION
Este PR implementa uma funcionalidade que permite a remoção automática de jogadores com anotações negativas, aproveitando a anotação já existente no sistema da GamersClub. Essa funcionalidade é útil para hosts que desejam manter a qualidade da sala sem intervenção manual.

## Detalhes Técnicos:

- A lógica percorre todos os jogadores da sala, ignorando o primeiro (usuário atual).
- Para cada jogador, verifica se possui uma anotação negativa (classe .PlayerAnnotations--negative).
- Caso identificado, extrai o idplayer do atributo id presente no wrapper do tipo #player-trigger-wrapper-<id>.
- Realiza uma requisição POST assíncrona para o endpoint oficial da GamersClub:

## Considerações:
- A funcionalidade respeita o fluxo da GC, utilizando headers e formato de dados compatíveis com o que é usado na interface oficial.
- Dependente de permissão de host na sala para funcionar corretamente, ou seja mesmo que a requisição seja enviada o usuário não será removido se não tiver permissão.