### PR TITLE
fix: ajusta regex para capturar objeto com caracteres especiais no no…

### DIFF
--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -1,5 +1,7 @@
 export function getUserInfo() {
-  const rawUserObject = document.documentElement.innerHTML.match( /window\.hj\('identify', userId, ({[^}]*})/ )?.[1];
+  const rawUserObject = document.documentElement.innerHTML.match(
+    /window\.hj\('identify',\s*userId,\s*({[\s\S]*?})\s*\)/
+  )?.[1];
   const doubleQuotedUserObject = rawUserObject.replace( /'/g, '"' );
   const userObject = JSON.parse( doubleQuotedUserObject );
   return userObject;


### PR DESCRIPTION
…me do usuário.

A regex usada para extrair o objeto do usuário quebrava quando o nome continha caracteres especiais como `{`, `}`, `*` ou espaços extras.   Foi substituída por `[\s\S]*?` para permitir
qualquer caractere até o fechamento correto da função `window.hj('identify', ...)`.