### PR TITLE
Ajuste no KDR da lobby atual

### DIFF
--- a/src/content-scripts/lobby/mostrarKdr.js
+++ b/src/content-scripts/lobby/mostrarKdr.js
@@ -238,11 +238,12 @@ export const mostrarInfoPlayerIntervaler = () => {
           if ( $element.attr( 'id' ) === undefined || $element.attr( 'id' ) === '' ) {
             const $nodeChildren = $element.find( '.LobbyPlayerHorizontal__nickname' );
 
-            const kdrInfos = $element.find( '.LobbyPlayerHorizontal__kdr' );
-            const kdrValue = kdrInfos.text().split( 'KDR' )[1];
-
             const playerLink = $nodeChildren.children( 'a' ).attr( 'href' );
             const playerId = playerLink?.split( '/' ).pop() ;
+
+            const kdr = await fetchKdr( playerId );
+            const kdrValue = parseFloat( kdr ).toFixed( 2 );
+
             $element.attr( 'id', `gcboost-content-${playerId}` );
 
             await getPlayerInfo( playerId ).then( infoPlayer => {


### PR DESCRIPTION
A GamersClub alterou o formato antigo em que buscava as informações do PlayerCard ao entrar em uma lobby.
Agora, o card mostra informações apenas das últimas 10 partidas dos últimos 6 meses:
<img width="359" height="282" alt="image" src="https://github.com/user-attachments/assets/152237a5-84fc-4d7e-8aee-b7555f602eab" />
Além disso, agora, esses dados são buscados dinamicamente. É feito uma requisição à rota de `player-card` após um hover no avatar do player, não trazendo os dados diretamente no HTML (formato com que o código buscava o KDR do player).
O ajuste usa a função pré-existente `fetchKdr` (com cache de 20 minutos) para buscar o KDR do mês atual por buscar da rota `history`, buscando a compatibilidade com o formato de KDR que o GamersClub-Booster entrega.

tl;dr a gc trocou o formato de busca de dados do PlayerCard filtrando somente as 10 ultimas partidas do player e buscando as informações dinamicamente, o ajuste corrige isso da busca dinamica e ajusta para o formato que o GCBooster já usa (KDR do mês atual).