### PR TITLE
Feature/autoready 5s 10s development

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -299,6 +299,64 @@ input:not([type="range"]) {
   user-select: none;
 }
 
+.ready-delay-setting {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.ready-delay-setting .container {
+  margin-bottom: 0;
+  flex: 1;
+}
+
+.ready-delay-options {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ready-delay-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-width: 48px;
+  padding: 4px 8px;
+  border: 1px solid #247eb9;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+  transition: 0.2s ease-out;
+  font-size: 12px;
+  font-weight: 600;
+  background: rgba(20, 21, 38, 0.5);
+}
+
+.ready-delay-chip:hover {
+  background: rgba(36, 126, 185, 0.18);
+}
+
+.ready-delay-chip input {
+  margin: 0;
+}
+
+.ready-delay-chip-active {
+  background: rgba(36, 126, 185, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(36, 126, 185, 0.45);
+}
+
+.ready-delay-chip-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.ready-delay-chip-disabled:hover {
+  background: rgba(20, 21, 38, 0.5);
+}
+
 /* Hide the browser's default checkbox */
 .container input {
   position: absolute;

--- a/public/styles.css
+++ b/public/styles.css
@@ -322,9 +322,10 @@ input:not([type="range"]) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  position: relative;
   min-width: 48px;
-  padding: 4px 8px;
+  min-height: 48px;
+  padding: 0 12px;
   border: 1px solid #247eb9;
   border-radius: 4px;
   color: #fff;
@@ -340,12 +341,22 @@ input:not([type="range"]) {
 }
 
 .ready-delay-chip input {
-  margin: 0;
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .ready-delay-chip-active {
   background: rgba(36, 126, 185, 0.35);
   box-shadow: inset 0 0 0 1px rgba(36, 126, 185, 0.45);
+}
+
+.ready-delay-chip span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  letter-spacing: 0.03em;
 }
 
 .ready-delay-chip-disabled {

--- a/src/content-scripts/lobby/autoAceitarReady.js
+++ b/src/content-scripts/lobby/autoAceitarReady.js
@@ -1,34 +1,391 @@
-export const autoAceitarReady = mutations =>
-  chrome.storage.sync.get( [ 'autoAceitarReady' ], function ( result ) {
-    if ( result.autoAceitarReady ) {
-      $.each( mutations, ( i, mutation ) => {
-        const addedNodes = $( mutation.addedNodes );
-        //eslint-disable-next-line
-        const selector = "button:contains('Ready')";
-        const readyButton = addedNodes.find( selector ).addBack( selector );
-        if ( readyButton && readyButton.length && !readyButton.disabled ) {
-          setTimeout( () => {
-            readyButton[0].click();
-            readyButton[0].trigger( 'click' );
-          }, 150 );
-        }
-      } );
+/*
+ * O que esse arquivo faz: controla o auto aceite do Ready da GC, incluindo o modo instantaneo
+ * e o modo com delay/popup para o usuario decidir se quer assumir manualmente aquela ocorrencia.
+ * Como ele funciona: mantem uma sessao local do botao Ready atual, evita timers/popup duplicados,
+ * aplica o delay configurado e limpa o estado quando a ocorrencia termina ou muda de contexto.
+ * Riscos de onde mexer: a sessao local depende de timing, rerender do DOM e polling existente.
+ * Alteracoes sem cuidado aqui podem rearmar o Ready apos decisao manual, duplicar popup ou aceitar
+ * a partida na ocorrencia errada.
+ */
+
+// Vulnerability note:
+// Ready detection still relies on button text matching.
+// If GamersClub changes the label, language, or DOM structure,
+// auto ready and the delay popup may stop working or target the wrong button.
+// Keep this selector isolated here so it can be replaced safely.
+const READY_SELECTOR = 'button:contains("Ready")';
+const READY_POPUP_ID = 'gc-booster-ready-delay-popup';
+const READY_POPUP_STYLE_ID = 'gc-booster-ready-delay-popup-style';
+const READY_CLICK_DELAY_MS = 150;
+const READY_SESSION_RESET_GRACE_MS = 600;
+const MANUAL_OVERRIDE_TTL_MS = 15000;
+
+const readySession = {
+  activeReadyElement: null,
+  pendingAcceptTimeout: null,
+  pendingAcceptMode: null,
+  pendingPopupElement: null,
+  pendingCountdownInterval: null,
+  manualOverrideUntil: 0,
+  autoAccepted: false,
+  sessionToken: 0,
+  countdownEndsAt: null,
+  readyAbsentSince: null
+};
+
+let readySessionCounter = 0;
+
+function getAutoReadySettings( callback ) {
+  chrome.storage.sync.get( [
+    'autoAceitarReady',
+    'autoAceitarReadyDelay5s',
+    'autoAceitarReadyDelay10s'
+  ], callback );
+}
+
+function getDelayMs( settings ) {
+  if ( settings.autoAceitarReadyDelay5s ) {
+    return 5000;
+  }
+
+  if ( settings.autoAceitarReadyDelay10s ) {
+    return 10000;
+  }
+
+  return 0;
+}
+
+function getReadyButton() {
+  return $( READY_SELECTOR ).filter( ( _index, element ) => {
+    return !element.disabled;
+  } ).first();
+}
+
+function clearPendingAcceptTimeout() {
+  if ( readySession.pendingAcceptTimeout ) {
+    clearTimeout( readySession.pendingAcceptTimeout );
+    readySession.pendingAcceptTimeout = null;
+  }
+  readySession.pendingAcceptMode = null;
+}
+
+function clearPendingCountdownInterval() {
+  if ( readySession.pendingCountdownInterval ) {
+    clearInterval( readySession.pendingCountdownInterval );
+    readySession.pendingCountdownInterval = null;
+  }
+}
+
+function removeReadyPopup() {
+  if ( readySession.pendingPopupElement ) {
+    readySession.pendingPopupElement.remove();
+    readySession.pendingPopupElement = null;
+  }
+}
+
+function clearPendingDelayArtifacts() {
+  if ( readySession.pendingAcceptMode === 'delay' ) {
+    clearPendingAcceptTimeout();
+  }
+  clearPendingCountdownInterval();
+  removeReadyPopup();
+  readySession.countdownEndsAt = null;
+}
+
+function resetReadySession() {
+  clearPendingDelayArtifacts();
+  readySession.activeReadyElement = null;
+  readySession.manualOverrideUntil = 0;
+  readySession.autoAccepted = false;
+  readySession.readyAbsentSince = null;
+}
+
+function ensureReadyPopupStyles() {
+  if ( document.getElementById( READY_POPUP_STYLE_ID ) ) {
+    return;
+  }
+
+  const style = document.createElement( 'style' );
+  style.id = READY_POPUP_STYLE_ID;
+  style.textContent = `
+    #${READY_POPUP_ID} {
+      position: fixed;
+      right: 24px;
+      bottom: 24px;
+      width: 320px;
+      padding: 16px;
+      border: 1px solid rgba(36, 126, 185, 0.75);
+      border-radius: 8px;
+      background: rgba(20, 21, 38, 0.96);
+      color: #ffffff;
+      z-index: 999999;
+      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+      font-family: Poppins, sans-serif;
     }
+    #${READY_POPUP_ID} .gc-booster-ready-title {
+      font-size: 15px;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    #${READY_POPUP_ID} .gc-booster-ready-subtitle {
+      font-size: 13px;
+      color: rgba(255, 255, 255, 0.8);
+      margin-bottom: 12px;
+    }
+    #${READY_POPUP_ID} .gc-booster-ready-actions {
+      display: flex;
+      gap: 8px;
+    }
+    #${READY_POPUP_ID} .gc-booster-ready-button {
+      flex: 1;
+      border: 0;
+      border-radius: 4px;
+      padding: 10px 12px;
+      color: #ffffff;
+      cursor: pointer;
+      font-size: 12px;
+      font-weight: 600;
+      transition: 0.2s ease-out;
+    }
+    #${READY_POPUP_ID} .gc-booster-ready-button--manual {
+      background: rgba(244, 67, 54, 0.92);
+    }
+    #${READY_POPUP_ID} .gc-booster-ready-button--manual:hover {
+      background: rgba(188, 39, 28, 0.95);
+    }
+    #${READY_POPUP_ID} .gc-booster-ready-button--auto {
+      background: rgba(36, 126, 185, 0.92);
+    }
+    #${READY_POPUP_ID} .gc-booster-ready-button--auto:hover {
+      background: rgba(27, 99, 146, 0.95);
+    }
+  `;
+
+  document.head.appendChild( style );
+}
+
+function isTrackedReadyStillValid() {
+  if ( !readySession.activeReadyElement ) {
+    return false;
+  }
+
+  return document.body.contains( readySession.activeReadyElement ) && !readySession.activeReadyElement.disabled;
+}
+
+function hasActiveManualOverride() {
+  return Date.now() < readySession.manualOverrideUntil;
+}
+
+function bindReadySession( readyButton ) {
+  const readyElement = readyButton.get( 0 );
+
+  if ( readySession.activeReadyElement === readyElement ) {
+    // O que essa linha de codigo faz: zera o marcador de ausencia quando o mesmo botao
+    // continua valido no DOM.
+    // Como afeta o programa: evita resetar a sessao atual por engano enquanto a mesma
+    // ocorrencia de Ready ainda esta viva.
+    readySession.readyAbsentSince = null;
+    return;
+  }
+
+  // O que essa linha de codigo faz: limpa somente artefatos temporarios do delay/popup
+  // antes de associar a sessao a um novo elemento Ready.
+  // Como afeta o programa: permite sobreviver a rerenders do mesmo estado de Ready sem
+  // transformar a escolha manual do usuario em um reset total da sessao.
+  clearPendingDelayArtifacts();
+  readySession.activeReadyElement = readyElement;
+  readySession.sessionToken = ++readySessionCounter;
+  readySession.autoAccepted = false;
+  readySession.readyAbsentSince = null;
+}
+
+function updatePopupCountdown() {
+  if ( !readySession.pendingPopupElement || !readySession.countdownEndsAt ) {
+    return;
+  }
+
+  const countdownNode = readySession.pendingPopupElement.find( '[data-role="countdown"]' );
+  const remainingMs = Math.max( readySession.countdownEndsAt - Date.now(), 0 );
+  const remainingSeconds = Math.max( Math.ceil( remainingMs / 1000 ), 0 );
+  countdownNode.text( `${remainingSeconds}s` );
+}
+
+function attemptReadyAcceptance( sessionToken ) {
+  if ( sessionToken !== readySession.sessionToken ) {
+    return;
+  }
+
+  if ( hasActiveManualOverride() || readySession.autoAccepted ) {
+    return;
+  }
+
+  if ( !isTrackedReadyStillValid() ) {
+    resetReadySession();
+    return;
+  }
+
+  clearPendingDelayArtifacts();
+  readySession.autoAccepted = true;
+
+  const readyButton = $( readySession.activeReadyElement );
+  readyButton[0].click();
+}
+
+function scheduleReadyAcceptance( sessionToken, delayMs, mode ) {
+  clearPendingAcceptTimeout();
+  readySession.pendingAcceptMode = mode;
+  readySession.pendingAcceptTimeout = setTimeout( () => {
+    readySession.pendingAcceptTimeout = null;
+    readySession.pendingAcceptMode = null;
+    attemptReadyAcceptance( sessionToken );
+  }, delayMs );
+}
+
+function renderReadyPopup( sessionToken, delayMs ) {
+  ensureReadyPopupStyles();
+  removeReadyPopup();
+
+  const popup = $( `
+    <div id="${READY_POPUP_ID}">
+      <div class="gc-booster-ready-title">Aceitar automaticamente esta partida?</div>
+      <div class="gc-booster-ready-subtitle">
+        Você pode decidir manualmente nos próximos <strong data-role="countdown">${Math.ceil( delayMs / 1000 )}s</strong>.
+      </div>
+      <div class="gc-booster-ready-actions">
+        <button type="button" class="gc-booster-ready-button gc-booster-ready-button--manual" data-action="manual">
+          Decidir manualmente
+        </button>
+        <button type="button" class="gc-booster-ready-button gc-booster-ready-button--auto" data-action="auto">
+          Aceitar automático
+        </button>
+      </div>
+    </div>
+  ` );
+
+  popup.find( '[data-action="manual"]' ).on( 'click', () => {
+    if ( sessionToken !== readySession.sessionToken ) {
+      return;
+    }
+
+    // O que essa linha de codigo faz: cria uma janela temporaria em que o auto aceite
+    // fica proibido para esta ocorrencia, mesmo se a GC rerenderizar o botao.
+    // Como afeta o programa: respeita a decisao do usuario de assumir manualmente sem
+    // desativar a feature para as proximas partidas.
+    readySession.manualOverrideUntil = Date.now() + MANUAL_OVERRIDE_TTL_MS;
+    clearPendingDelayArtifacts();
   } );
 
+  popup.find( '[data-action="auto"]' ).on( 'click', () => {
+    if ( sessionToken !== readySession.sessionToken ) {
+      return;
+    }
+
+    attemptReadyAcceptance( sessionToken );
+  } );
+
+  $( 'body' ).append( popup );
+  readySession.pendingPopupElement = popup;
+  readySession.countdownEndsAt = Date.now() + delayMs;
+  updatePopupCountdown();
+
+  clearPendingCountdownInterval();
+  readySession.pendingCountdownInterval = setInterval( () => {
+    if ( sessionToken !== readySession.sessionToken ) {
+      clearPendingCountdownInterval();
+      return;
+    }
+
+    if ( !isTrackedReadyStillValid() ) {
+      resetReadySession();
+      return;
+    }
+
+    updatePopupCountdown();
+  }, 250 );
+}
+
+function ensureDelayedAcceptance( delayMs ) {
+  if ( hasActiveManualOverride() || readySession.autoAccepted || readySession.pendingAcceptTimeout ) {
+    return;
+  }
+
+  renderReadyPopup( readySession.sessionToken, delayMs );
+  scheduleReadyAcceptance( readySession.sessionToken, delayMs, 'delay' );
+}
+
+function processAutoReady( settings ) {
+  if ( !settings.autoAceitarReady ) {
+    resetReadySession();
+    return;
+  }
+
+  const readyButton = getReadyButton();
+  if ( !readyButton.length ) {
+    if ( !readySession.readyAbsentSince ) {
+      // O que essa linha de codigo faz: marca quando o Ready deixou de existir no DOM.
+      // Como afeta o programa: cria uma pequena janela de tolerancia para diferenciar
+      // um rerender rapido de um fim real da ocorrencia.
+      readySession.readyAbsentSince = Date.now();
+      return;
+    }
+
+    if ( Date.now() - readySession.readyAbsentSince >= READY_SESSION_RESET_GRACE_MS ) {
+      // O que essa linha de codigo faz: encerra completamente a sessao apos o Ready
+      // ficar ausente pelo tempo minimo definido.
+      // Como afeta o programa: permite que a proxima partida reative normalmente o fluxo
+      // de popup/delay, sem manter a decisao manual presa para sempre.
+      resetReadySession();
+    }
+    return;
+  }
+
+  bindReadySession( readyButton );
+
+  if ( !isTrackedReadyStillValid() ) {
+    resetReadySession();
+    return;
+  }
+
+  if ( hasActiveManualOverride() || readySession.autoAccepted ) {
+    return;
+  }
+
+  const delayMs = getDelayMs( settings );
+  if ( delayMs > 0 ) {
+    // O que essa linha de codigo faz: troca o fluxo legado instantaneo pelo fluxo hibrido
+    // com countdown e popup de decisao.
+    // Como afeta o programa: da ao usuario uma janela curta para assumir manualmente
+    // antes do aceite automatico.
+    ensureDelayedAcceptance( delayMs );
+    return;
+  }
+
+  // O que essa linha de codigo faz: remove qualquer popup ou countdown pendente quando
+  // o usuario nao escolheu um modo de delay.
+  // Como afeta o programa: preserva o comportamento antigo de auto aceite rapido e evita
+  // lixo visual vindo de uma configuracao anterior.
+  clearPendingDelayArtifacts();
+
+  if ( readySession.pendingAcceptTimeout ) {
+    return;
+  }
+
+  scheduleReadyAcceptance( readySession.sessionToken, READY_CLICK_DELAY_MS, 'click' );
+}
+
+export const autoAceitarReady = _mutations =>
+  getAutoReadySettings( processAutoReady );
+
 export function autoAceitarReadySetInterval() {
-  setInterval( async () => {
-    chrome.storage.sync.get( [ 'autoAceitarReady' ], function ( result ) {
-      if ( result.autoAceitarReady ) {
-        // eslint-disable-next-line
-        const readyButton = $( "button:contains('Ready')" );
-        if ( readyButton.length ) {
-          setTimeout( () => {
-            readyButton[0].click();
-            readyButton[0].trigger( 'click' );
-          }, 150 );
-        }
-      }
-    } );
+  setInterval( () => {
+    // O que essa linha de codigo faz: revalida periodicamente a existencia do Ready e o
+    // estado salvo da feature.
+    // Como afeta o programa: garante que o fluxo continue funcionando mesmo quando o
+    // observer nao captura a mudanca de DOM sozinho.
+    getAutoReadySettings( processAutoReady );
   }, 300 );
+}
+
+export function resetAutoAceitarReadyState() {
+  resetReadySession();
 }

--- a/src/content-scripts/lobby/index.js
+++ b/src/content-scripts/lobby/index.js
@@ -1,4 +1,4 @@
-import { autoAceitarReady, autoAceitarReadySetInterval } from './autoAceitarReady';
+import { autoAceitarReady, autoAceitarReadySetInterval, resetAutoAceitarReadyState } from './autoAceitarReady';
 import { autoConcordarTermosRanked } from './autoConcordarTermosRanked';
 import { autoFixarMenuLobby } from './autoFixarMenuLobby';
 import { adicionarBotaoAutoComplete } from './botaoAutoComplete';
@@ -31,6 +31,11 @@ chrome.storage.sync.get( null, function ( _result ) {
 const initLobby = async () => {
   // Resetar estado do auto copy lobby link quando entrar no lobby
   resetLobbyLinkState();
+  // O que essa linha de codigo faz: limpa a sessao anterior do auto aceite ao entrar
+  // em um novo contexto de lobby.
+  // Como afeta o programa: impede que uma decisao manual ou timer pendente vaze para a
+  // proxima partida.
+  resetAutoAceitarReadyState();
 
   // Esses dois não estão funcionando, verificar o motivo, criei o intervaler pra substituir por enquanto...
   criarObserver( '.lobby,.ranking', somReady );

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -168,11 +168,25 @@
     <!-- GERAL -->
     <div class="pagina" id="geral">
       <h3 class="subtitulo" translation-key="automacoes"></h3>
-      <label class="container" for="autoAceitarReady" title="Aceita automaticamente o ready">
-        <p class="descricao" translation-key="aceitar-ready"></p>
-        <input type="checkbox" id="autoAceitarReady" />
-        <span class="checkmark"></span>
-      </label>
+      <div class="ready-delay-setting">
+        <label class="container" for="autoAceitarReady" title="Aceita automaticamente o ready">
+          <p class="descricao" translation-key="aceitar-ready"></p>
+          <input type="checkbox" id="autoAceitarReady" />
+          <span class="checkmark"></span>
+        </label>
+        <div class="ready-delay-options" id="autoAceitarReadyDelayOptions">
+          <label class="ready-delay-chip" for="autoAceitarReadyDelay5s"
+            title="Espera 5 segundos antes de aceitar automaticamente. Nesse tempo você pode decidir manualmente.">
+            <input type="checkbox" id="autoAceitarReadyDelay5s" />
+            <span>5s</span>
+          </label>
+          <label class="ready-delay-chip" for="autoAceitarReadyDelay10s"
+            title="Espera 10 segundos antes de aceitar automaticamente. Nesse tempo você pode decidir manualmente.">
+            <input type="checkbox" id="autoAceitarReadyDelay10s" />
+            <span>10s</span>
+          </label>
+        </div>
+      </div>
 
       <label class="container" for="autoCopiarIp" title="Copia o IP automáticamente assim que disponível"
         style="display: none">

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -13,6 +13,8 @@ const translations = {
   'fr': fr
 };
 
+const autoReadyDelayKeys = [ 'autoAceitarReadyDelay5s', 'autoAceitarReadyDelay10s' ];
+
 function saveJson( obj ) {
   const myArray = JSON.stringify( obj, null, 4 );
   const vLink = document.createElement( 'a' ),
@@ -43,6 +45,7 @@ function iniciarPaginaOpcoes() {
   marcarPreVetos();
   marcarCompleteMapas();
   adicionarListenersFeatures();
+  iniciarOpcoesDelayReady();
   adicionarListenersPaginas();
   adicionarListenerPreVetos();
   adicionarListenerCompleteMapas();
@@ -292,6 +295,96 @@ function adicionarListenersFeatures() {
       chrome.storage.sync.set( { [feature]: this.checked }, function () {} );
     } );
   }
+}
+
+function iniciarOpcoesDelayReady() {
+  // O que essa linha de codigo faz: centraliza a configuracao visual e funcional dos
+  // chips de delay do Ready no popup da extensao.
+  // Como afeta o programa: mantem 5s/10s sincronizados com o checkbox principal e com
+  // o storage, evitando combinacoes invalidas na UI.
+  const autoReadyCheckbox = document.getElementById( 'autoAceitarReady' );
+  const delay5Checkbox = document.getElementById( 'autoAceitarReadyDelay5s' );
+  const delay10Checkbox = document.getElementById( 'autoAceitarReadyDelay10s' );
+
+  const updateDelayChipVisualState = () => {
+    for ( const key of autoReadyDelayKeys ) {
+      const checkbox = document.getElementById( key );
+      const label = checkbox.closest( '.ready-delay-chip' );
+      label.classList.toggle( 'ready-delay-chip-active', checkbox.checked );
+    }
+  };
+
+  const setDelayOptionsDisabled = disabled => {
+    for ( const key of autoReadyDelayKeys ) {
+      const checkbox = document.getElementById( key );
+      const label = checkbox.closest( '.ready-delay-chip' );
+      checkbox.disabled = disabled;
+      label.classList.toggle( 'ready-delay-chip-disabled', disabled );
+    }
+  };
+
+  chrome.storage.sync.get( [ 'autoAceitarReady', ...autoReadyDelayKeys ], response => {
+    const normalized = { ...response };
+    if ( normalized.autoAceitarReadyDelay5s && normalized.autoAceitarReadyDelay10s ) {
+      // O que essa linha de codigo faz: corrige estado salvo invalido onde os dois delays
+      // aparecem ligados ao mesmo tempo.
+      // Como afeta o programa: garante que o contrato de exclusividade continue valido
+      // mesmo apos importacao de backup ou configuracao antiga.
+      normalized.autoAceitarReadyDelay10s = false;
+      chrome.storage.sync.set( { autoAceitarReadyDelay10s: false } );
+    }
+
+    delay5Checkbox.checked = Boolean( normalized.autoAceitarReadyDelay5s );
+    delay10Checkbox.checked = Boolean( normalized.autoAceitarReadyDelay10s );
+    updateDelayChipVisualState();
+    setDelayOptionsDisabled( !normalized.autoAceitarReady );
+  } );
+
+  autoReadyCheckbox.addEventListener( 'change', function () {
+    // O que essa linha de codigo faz: habilita ou desabilita os delays conforme o estado
+    // do Aceitar Ready principal.
+    // Como afeta o programa: deixa claro para o usuario que 5s/10s sao complementos da
+    // feature, nao automacoes independentes.
+    setDelayOptionsDisabled( !this.checked );
+  } );
+
+  delay5Checkbox.addEventListener( 'change', function () {
+    if ( this.disabled ) {
+      this.checked = false;
+      return;
+    }
+
+    const updates = {
+      autoAceitarReadyDelay5s: this.checked,
+      autoAceitarReadyDelay10s: this.checked ? false : delay10Checkbox.checked
+    };
+
+    // O que essa linha de codigo faz: desmarca visualmente o delay concorrente quando o
+    // usuario escolhe 5s.
+    // Como afeta o programa: impede que a UI apresente dois delays ativos ao mesmo tempo.
+    delay10Checkbox.checked = updates.autoAceitarReadyDelay10s;
+    updateDelayChipVisualState();
+    chrome.storage.sync.set( updates );
+  } );
+
+  delay10Checkbox.addEventListener( 'change', function () {
+    if ( this.disabled ) {
+      this.checked = false;
+      return;
+    }
+
+    const updates = {
+      autoAceitarReadyDelay10s: this.checked,
+      autoAceitarReadyDelay5s: this.checked ? false : delay5Checkbox.checked
+    };
+
+    // O que essa linha de codigo faz: desmarca visualmente o delay concorrente quando o
+    // usuario escolhe 10s.
+    // Como afeta o programa: preserva a exclusividade entre os modos de atraso.
+    delay5Checkbox.checked = updates.autoAceitarReadyDelay5s;
+    updateDelayChipVisualState();
+    chrome.storage.sync.set( updates );
+  } );
 }
 
 function adicionarListenersPaginas() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,12 +3,13 @@ const CopyPlugin = require( 'copy-webpack-plugin' );
 const webpack = require( 'webpack' );
 const glob = require( 'glob' );
 
-const contentScripts = name => glob.sync( `./src/content-scripts/${name}/*.js` );
+const resolveEntries = pattern => glob.sync( pattern ).map( entry => path.resolve( __dirname, entry ) );
+const contentScripts = name => resolveEntries( `./src/content-scripts/${name}/*.js` );
 
 module.exports = {
   mode: 'production',
   entry: {
-    'index': glob.sync( './src/options/*.js' ),
+    'index': resolveEntries( './src/options/*.js' ),
     'content-scripts/main': contentScripts( 'main' ),
     'content-scripts/lobby': contentScripts( 'lobby' ),
     'content-scripts/missions': contentScripts( 'missions' ),

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -3,12 +3,13 @@ const CopyPlugin = require( 'copy-webpack-plugin' );
 const webpack = require( 'webpack' );
 const glob = require( 'glob' );
 
-const contentScripts = name => glob.sync( `./src/content-scripts/${name}/*.js` );
+const resolveEntries = pattern => glob.sync( pattern ).map( entry => path.resolve( __dirname, entry ) );
+const contentScripts = name => resolveEntries( `./src/content-scripts/${name}/*.js` );
 
 module.exports = {
   mode: 'development',
   entry: {
-    'index': glob.sync( './src/options/*.js' ),
+    'index': resolveEntries( './src/options/*.js' ),
     'content-scripts/main': contentScripts( 'main' ),
     'content-scripts/lobby': contentScripts( 'lobby' ),
     'content-scripts/missions': contentScripts( 'missions' ),


### PR DESCRIPTION

<img width="980" height="760" alt="general" src="https://github.com/user-attachments/assets/9bb1ae8a-45c2-4bf0-8ff6-742f9dd126a9" />

<img width="980" height="760" alt="popup" src="https://github.com/user-attachments/assets/978dfab9-9113-496e-b316-0ae123a1551e" />


## Resumo

Este PR adiciona um modo híbrido ao `Aceitar Ready`, permitindo configurar um atraso de `5s` ou `10s` antes do aceite automático.

Durante esse tempo, o usuário pode escolher decidir manualmente ou deixar o fluxo automático seguir normalmente. A ideia é dar mais controle para evitar aceitar partidas indesejadas, sem perder a praticidade da automação.

## Alterações

- adiciona opções de delay `5s` e `10s` ao lado de `Aceitar Ready`
- mantém o comportamento atual quando nenhum delay está ativo
- exibe um popup com opção de decisão manual ou aceite automático
- evita timers e popups duplicados
- preserva a escolha manual mesmo com rerender do DOM
- melhora a clareza dos textos da feature

## Validação

- `npm.cmd run build`
- `npm.cmd run lint`

------------------------------------------------------------------------------------------------

## Summary

Add a hybrid delayed autoready flow for Ready acceptance.

This keeps the original instant autoready behavior when no delay is selected, and adds optional `5s` / `10s` delay modes with a confirmation popup that lets the user decide manually before the automatic acceptance happens.

## What changed

- add `5s` and `10s` delay options next to `Aceitar Ready`
- keep delay options visible but disabled when `Aceitar Ready` is off
- enforce mutual exclusivity between `5s` and `10s`
- add delayed autoready popup with:
  - `Decidir manualmente`
  - `Aceitar automático`
- prevent duplicate popup / duplicate timer issues
- preserve manual decision during fast DOM rerenders of the same Ready occurrence
- re-enable the feature normally for the next Ready occurrence
- improve microcopy for first use clarity
- document critical logic and selector fragility in code comments
- fix webpack entry resolution for Windows local builds

## Validation

- `npm.cmd run build`
- `npm.cmd run lint`

## Notes

- Ready detection still depends on text matching in the button selector.
- This PR improves resilience around rerenders, but selector fragility is still explicitly documented in code.