### PR TITLE
feat: add CS2 steam hours display on lobby player badges

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,9 +10,14 @@
   "host_permissions": [
     "https://*.gamersclub.com.br/",
     "https://cs.gamersclub.gg/",
-    "https://discord.com/api/webhooks/*"
+    "https://discord.com/api/webhooks/*",
+    "https://api.steampowered.com/*",
+    "https://steamcommunity.com/*"
   ],
   "permissions": ["storage"],
+  "background": {
+    "service_worker": "background.js"
+  },
   "content_scripts": [
     {
       "matches": ["*://*.gamersclub.com.br/*", "*://cs.gamersclub.gg/*"],

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,0 +1,9 @@
+chrome.runtime.onMessage.addListener( ( request, sender, sendResponse ) => {
+  if ( request.action === 'fetchSteam' ) {
+    fetch( request.url )
+      .then( response => response.json() )
+      .then( data => sendResponse( { success: true, data } ) )
+      .catch( error => sendResponse( { success: false, error: error.message } ) );
+    return true; // Keep message channel open for asynchronous response
+  }
+} );

--- a/src/content-scripts/lobby/index.js
+++ b/src/content-scripts/lobby/index.js
@@ -5,7 +5,7 @@ import { adicionarBotaoAutoComplete } from './botaoAutoComplete';
 // import { adicionarBotaoForcarCriarLobby } from './botaoForcarCriarLobby';
 import { lobbyLink } from './lobbyLink';
 import { autoCopyLobbyLink, resetLobbyLinkState } from './autoCopyLobbyLink';
-import { mostrarInfoPlayerIntervaler, mostrarKdr, mostrarKdrDesafios, mostrarKdrRanked, showKdrMatch } from './mostrarKdr';
+import { mostrarInfoPlayerIntervaler, mostrarKdr, mostrarKdrDesafios, mostrarKdrRanked, showKdrMatch, showHoursMyRoom } from './mostrarKdr';
 import { partidaInfo } from './partidaInfo';
 import { somReady, somReadySetInterval, tocarSomSeVoceForExpulsoDaLobby } from './sons';
 import { adicionarFiltroKdr } from './filtrarKdr';
@@ -83,11 +83,16 @@ const initLobby = async () => {
   lobbyMapSuggestions();
   showPlayerSoloStats();
   showKdrMatch();
+  showHoursMyRoom();
   adicionarFiltroKdr();
 };
 
 const criarObserver = ( seletor, exec, type ) => {
   const observer = new MutationObserver( mutations => {
+    if ( typeof chrome === 'undefined' || !chrome.runtime || !chrome.runtime.id ) {
+      observer.disconnect();
+      return;
+    }
 
     let shouldExec = false;
     mutations.forEach( mutation => {

--- a/src/content-scripts/lobby/mostrarKdr.js
+++ b/src/content-scripts/lobby/mostrarKdr.js
@@ -1,6 +1,142 @@
 import { GC_URL, headers, levelColor } from '../../lib/constants';
 import { getFromStorage, setStorage } from '../../lib/storage';
 
+const checkContext = () => {
+  return typeof chrome !== 'undefined' && chrome.runtime && !!chrome.runtime.id;
+};
+
+const getSyncStorage = keys => {
+  return new Promise( resolve => {
+    if ( !checkContext() ) {
+      resolve( {} );
+      return;
+    }
+    try {
+      chrome.storage.sync.get( keys, resolve );
+    } catch ( _e ) {
+      resolve( {} );
+    }
+  } );
+};
+
+const resolveVanityUrl = async vanityName => {
+  if ( !checkContext() ) { return null; }
+  const { steamApiKey } = await getSyncStorage( [ 'steamApiKey' ] );
+  if ( !steamApiKey ) { return null; }
+
+  return new Promise( resolve => {
+    if ( !checkContext() ) { resolve( null ); return; }
+    try {
+      chrome.runtime.sendMessage( {
+        action: 'fetchSteam',
+        url: `https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/?key=${steamApiKey}&vanityurl=${vanityName}`
+      }, response => {
+        if ( chrome.runtime.lastError ) {
+          resolve( null );
+        } else if ( response && response.success && response.data?.response?.success === 1 ) {
+          resolve( response.data.response.steamid );
+        } else {
+          resolve( null );
+        }
+      } );
+    } catch ( _e ) {
+      resolve( null );
+    }
+  } );
+};
+
+const getSteamId = async playerId => {
+  if ( !checkContext() ) { return null; }
+  const cache = await getFromStorage( 'steamIdCache' ) || {};
+  if ( cache[playerId] && cache[playerId].ttl > Date.now() ) {
+    return cache[playerId].steamId;
+  }
+
+  try {
+    // Fetch the player profile HTML — the Steam link is present in the static HTML
+    const response = await fetch( `https://${GC_URL}/jogador/${playerId}` );
+    const html = await response.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString( html, 'text/html' );
+    const steamLink = doc.querySelector( 'a[href*="steamcommunity.com"]' );
+    if ( !steamLink ) { return null; }
+
+    const href = steamLink.href;
+    let steamId = null;
+    if ( href.includes( '/profiles/' ) ) {
+      steamId = href.split( '/profiles/' )[1].split( '/' )[0].trim();
+    } else if ( href.includes( '/id/' ) ) {
+      const vanityName = href.split( '/id/' )[1].split( '/' )[0].trim();
+      steamId = await resolveVanityUrl( vanityName );
+    }
+
+    if ( steamId ) {
+      cache[playerId] = { steamId, ttl: Date.now() + ( 7 * 24 * 60 * 60 * 1000 ) }; // 7 days
+      if ( checkContext() ) { await setStorage( 'steamIdCache', cache ); }
+    }
+    return steamId;
+  } catch ( err ) {
+    console.error( '[GCB] Error fetching Steam ID for player', playerId, err );
+    return null;
+  }
+};
+
+
+const fetchCS2Hours = async playerId => {
+  if ( !checkContext() ) { return null; }
+  const { steamHours } = await getSyncStorage( [ 'steamHours' ] );
+  if ( !steamHours ) { return null; }
+
+  const { steamApiKey } = await getSyncStorage( [ 'steamApiKey' ] );
+  if ( !steamApiKey ) { return null; }
+
+  const cache = await getFromStorage( 'steamHoursCache' ) || {};
+  if ( cache[playerId] && cache[playerId].ttl > Date.now() ) {
+    return cache[playerId].hours;
+  }
+
+  const steamId = await getSteamId( playerId );
+  if ( !steamId ) { return 'private'; }
+
+  return new Promise( resolve => {
+    if ( !checkContext() ) { resolve( 'private' ); return; }
+    try {
+      chrome.runtime.sendMessage( {
+        action: 'fetchSteam',
+        url: `https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/?key=${steamApiKey}&steamid=${steamId}&format=json`
+      }, async response => {
+        if ( chrome.runtime.lastError ) {
+          resolve( 'private' );
+        } else if ( response && response.success && response.data?.response?.games ) {
+          const cs2Game = response.data.response.games.find( g => g.appid === 730 );
+          const hours = cs2Game ? Math.round( cs2Game.playtime_forever / 60 ) : 0;
+
+          cache[playerId] = { hours, ttl: Date.now() + ( 24 * 60 * 60 * 1000 ) }; // 24 hours cache
+          if ( checkContext() ) {
+            await setStorage( 'steamHoursCache', cache );
+          }
+          resolve( hours );
+        } else {
+          resolve( 'private' );
+        }
+      } );
+    } catch ( _e ) {
+      resolve( 'private' );
+    }
+  } );
+};
+
+const formatHours = hours => {
+  if ( typeof hours === 'number' ) {
+    if ( hours >= 1000 ) {
+      return ( hours / 1000 ).toFixed( 1 ).replace( '.0', '' ) + 'k h';
+    }
+    return hours + 'h';
+  }
+  if ( hours === 'private' ) { return 'Privado'; }
+  return null;
+};
+
 export const mostrarKdr = mutations => {
   $.each( mutations, async ( _, mutation ) => {
     $( mutation.addedNodes )
@@ -39,13 +175,45 @@ export const mostrarKdr = mutations => {
                 'linear-gradient(135deg, rgba(0,255,222,0.8) 0%, rgba(245,255,0,0.8) 30%, rgba(255,145,0,1) 60%, rgba(166,0,255,0.8) 100%)',
               'background-color': kdr <= 2.5 ? levelColor[Math.round( kdr * 10 )] + 'cc' : 'initial'
             }
-          } ).append( $( '<span/>', {
+          } );
+
+          const $span = $( '<span/>', {
             'id': 'gcbooster_kdr_span',
             'gcbooster_kdr_lobby': lobbyId,
             'text': kdr,
-            'kdr': kdr,
             'css': { 'width': '100%', 'font-size': '10px' }
-          } ) );
+          } );
+          $span.attr( 'data-kdr', kdr );
+          $span.attr( 'data-state', 'kdr' );
+
+          $kdrElement.append( $span );
+
+          $kdrElement.css( 'cursor', 'pointer' );
+          $kdrElement.on( 'click', function ( e ) {
+            e.preventDefault();
+            e.stopPropagation();
+            const current = $span.attr( 'data-state' ) || 'kdr';
+            if ( current === 'kdr' ) {
+              $span.text( $span.attr( 'data-hours' ) || '...' );
+              $span.attr( 'data-state', 'hours' );
+            } else {
+              $span.text( $span.attr( 'data-kdr' ) );
+              $span.attr( 'data-state', 'kdr' );
+            }
+          } );
+
+          ( async () => {
+            const playerId = $element.attr( 'href' )?.split( '/' ).pop();
+            if ( playerId ) {
+              const hours = await fetchCS2Hours( playerId );
+              const formatted = formatHours( hours );
+              if ( formatted ) {
+                $span.attr( 'data-hours', formatted );
+              } else {
+                $span.attr( 'data-hours', 'N/A' );
+              }
+            }
+          } )();
 
           $element.prepend( $kdrElement );
           $element.find( 'div.LobbyPlayer' ).append( '<style>.LobbyPlayer:before{top:15px !important;}</style>' );
@@ -128,12 +296,44 @@ export const mostrarKdrDesafios = () => {
                   'linear-gradient(135deg, rgba(0,255,222,0.8) 0%, rgba(245,255,0,0.8) 30%, rgba(255,145,0,1) 60%, rgba(166,0,255,0.8) 100%)',
                 'background-color': kdr <= 2.5 ? levelColor[Math.round( kdr * 10 )] + 'cc' : 'initial'
               }
-            } ).append( $( '<span/>', {
+            } );
+
+            const $span = $( '<span/>', {
               'id': 'gcbooster_kdr_span',
               'text': kdr,
-              'kdr': kdr,
               'css': { 'width': '100%', 'font-size': '10px' }
-            } ) );
+            } );
+            $span.attr( 'data-kdr', kdr );
+            $span.attr( 'data-state', 'kdr' );
+
+            $kdrElement.append( $span );
+
+            $kdrElement.css( 'cursor', 'pointer' );
+            $kdrElement.on( 'click', function ( e ) {
+              e.preventDefault();
+              e.stopPropagation();
+              const current = $span.attr( 'data-state' ) || 'kdr';
+              if ( current === 'kdr' ) {
+                $span.text( $span.attr( 'data-hours' ) || '...' );
+                $span.attr( 'data-state', 'hours' );
+              } else {
+                $span.text( $span.attr( 'data-kdr' ) );
+                $span.attr( 'data-state', 'kdr' );
+              }
+            } );
+
+            ( async () => {
+              const playerId = $element.attr( 'href' )?.split( '/' ).pop();
+              if ( playerId ) {
+                const hours = await fetchCS2Hours( playerId );
+                const formatted = formatHours( hours );
+                if ( formatted ) {
+                  $span.attr( 'data-hours', formatted );
+                } else {
+                  $span.attr( 'data-hours', 'N/A' );
+                }
+              }
+            } )();
 
             $element.prepend( $kdrElement );
             $element.find( 'div.LobbyPlayer' ).append( '<style>.LobbyPlayer:before{top:15px !important;}</style>' );
@@ -194,6 +394,10 @@ const fetchKdr = async id => {
 
 export const mostrarKdrRanked = () => {
   const kdrRankedInterval = setInterval( () => {
+    if ( !checkContext() ) {
+      clearInterval( kdrRankedInterval );
+      return;
+    }
     $( '[class^=PlayerCardWrapper] [id^=trigger-]' ).each( ( _, element ) => {
       ( async () => {
         const playerId = String( element.id ).split( '-' ).pop();
@@ -213,11 +417,43 @@ export const mostrarKdrRanked = () => {
           backgroundColor: colorKdr,
           fontSize: '12px',
           textAlign: 'center',
-          width: '2rem',
+          width: 'auto',
+          minWidth: '2rem',
+          padding: '0 4px',
           height: '1.5rem',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
           marginLeft: '4px',
-          order: 7
+          order: 7,
+          cursor: 'pointer'
         } ).text( playerKdr );
+
+        kdrDiv.attr( 'data-kdr', playerKdr );
+        kdrDiv.attr( 'data-state', 'kdr' );
+
+        kdrDiv.on( 'click', function ( e ) {
+          e.preventDefault();
+          e.stopPropagation();
+          const current = kdrDiv.attr( 'data-state' ) || 'kdr';
+          if ( current === 'kdr' ) {
+            kdrDiv.text( kdrDiv.attr( 'data-hours' ) || '...' );
+            kdrDiv.attr( 'data-state', 'hours' );
+          } else {
+            kdrDiv.text( kdrDiv.attr( 'data-kdr' ) );
+            kdrDiv.attr( 'data-state', 'kdr' );
+          }
+        } );
+
+        ( async () => {
+          const hours = await fetchCS2Hours( playerId );
+          const formatted = formatHours( hours );
+          if ( formatted ) {
+            kdrDiv.attr( 'data-hours', formatted );
+          } else {
+            kdrDiv.attr( 'data-hours', 'N/A' );
+          }
+        } )();
       } )();
     } );
 
@@ -228,10 +464,16 @@ export const mostrarKdrRanked = () => {
 };
 
 export const mostrarInfoPlayerIntervaler = () => {
+  if ( !checkContext() ) { return; }
   chrome.storage.sync.get( [ 'autoInfoPlayer' ], function ( result ) {
+    if ( chrome.runtime.lastError ) { return; }
     if ( result.autoInfoPlayer ) {
       document.body.classList.add( 'gboost-info-player' );
-      setInterval( () => {
+      const infoPlayerInterval = setInterval( () => {
+        if ( !checkContext() ) {
+          clearInterval( infoPlayerInterval );
+          return;
+        }
         $( '#integrantesLobbyShort .player' ).each( async ( _, player ) => {
           const $element = $( player );
 
@@ -245,7 +487,7 @@ export const mostrarInfoPlayerIntervaler = () => {
             const playerId = playerLink?.split( '/' ).pop() ;
             $element.attr( 'id', `gcboost-content-${playerId}` );
 
-            await getPlayerInfo( playerId ).then( infoPlayer => {
+            await getPlayerInfo( playerId ).then( async infoPlayer => {
               const completeUrl = getUrlFlag( infoPlayer?.countryFlag );
               const flagImg = `<img src="${completeUrl}" id="gcb-flag-${playerId}" alt="Flag" class="gcboost-flag b-lazy">`;
               const playerWins = infoPlayer?.currentMonthMatchesHistory?.wins || 0;
@@ -255,19 +497,50 @@ export const mostrarInfoPlayerIntervaler = () => {
                 'linear-gradient(135deg, rgba(0,255,222,0.8) 0%, rgba(245,255,0,0.8) 30%, rgba(255,145,0,1) 60%, rgba(166,0,255,0.8) 100%)';
               const colorKdr = kdrValue <= 2 ? levelColor[Math.round( kdrValue * 10 )] : colorKrdDefault;
 
+              const kdrText = kdrValue || '0.00';
+
               const infos = `
           <div class="gcboost-content">
             <div class="gcboost-result">
               <div class="wins">Vitórias: ${playerWins}</div>
-              <div class="gcboost-kdr-color" title="[GC Booster]: KDR médio: ${kdrValue}" style="background-color: ${colorKdr}">
-                ${kdrValue || '0.00'}
+              <div class="gcboost-kdr-color"
+                title="[GC Booster]: KDR médio: ${kdrValue}"
+                data-kdr="${kdrValue || '0.00'}"
+                data-state="kdr"
+                style="background-color: ${colorKdr}; width: auto; min-width: 40px; padding: 0 4px; cursor: pointer;">
+                ${kdrText}
               </div>
               <div class="losses">Derrotas: ${playerLoss}</div>
             </div>
           </div>`;
 
+              const $infos = $( infos );
+              const $kdrBadge = $infos.find( '.gcboost-kdr-color' );
+              $kdrBadge.on( 'click', function ( e ) {
+                e.preventDefault();
+                e.stopPropagation();
+                const current = $( this ).attr( 'data-state' ) || 'kdr';
+                if ( current === 'kdr' ) {
+                  $( this ).text( $( this ).attr( 'data-hours' ) || '...' );
+                  $( this ).attr( 'data-state', 'hours' );
+                } else {
+                  $( this ).text( $( this ).attr( 'data-kdr' ) );
+                  $( this ).attr( 'data-state', 'kdr' );
+                }
+              } );
+
               $nodeChildren.prepend( flagImg );
-              $element.append( infos );
+              $element.append( $infos );
+
+              ( async () => {
+                const hours = await fetchCS2Hours( playerId );
+                const formatted = formatHours( hours );
+                if ( formatted ) {
+                  $kdrBadge.attr( 'data-hours', formatted );
+                } else {
+                  $kdrBadge.attr( 'data-hours', 'N/A' );
+                }
+              } )();
 
             } ).catch( error => {
               console.error( 'Erro ao obter informações do jogador:', error );
@@ -276,12 +549,15 @@ export const mostrarInfoPlayerIntervaler = () => {
         } );
       }, 1000 );
     }
-  }
-  );
+  } );
 };
 
 export const showKdrMatch = () => {
   const observer = new MutationObserver( () => {
+    if ( !checkContext() ) {
+      observer.disconnect();
+      return;
+    }
     $( '[id^="trigger-"]' ).each( ( _, element ) => {
       if ( element.dataset.gcboosterProcessed ) {
         return;
@@ -319,11 +595,40 @@ export const showKdrMatch = () => {
             'text-align': 'center',
             'display': 'flex',
             'align-items': 'center',
-            'justify-content': 'center'
+            'justify-content': 'center',
+            'width': 'auto',
+            'min-width': '2rem',
+            'cursor': 'pointer'
           },
           'title': `[GC Booster]: KDR: ${playerKdr}`,
           'text': playerKdr
         } );
+
+        $kdrElement.attr( 'data-kdr', playerKdr );
+        $kdrElement.attr( 'data-state', 'kdr' );
+
+        $kdrElement.on( 'click', function ( e ) {
+          e.preventDefault();
+          e.stopPropagation();
+          const current = $( this ).attr( 'data-state' ) || 'kdr';
+          if ( current === 'kdr' ) {
+            $( this ).text( $( this ).attr( 'data-hours' ) || '...' );
+            $( this ).attr( 'data-state', 'hours' );
+          } else {
+            $( this ).text( $( this ).attr( 'data-kdr' ) );
+            $( this ).attr( 'data-state', 'kdr' );
+          }
+        } );
+
+        ( async () => {
+          const hours = await fetchCS2Hours( playerId );
+          const formatted = formatHours( hours );
+          if ( formatted ) {
+            $kdrElement.attr( 'data-hours', formatted );
+          } else {
+            $kdrElement.attr( 'data-hours', 'N/A' );
+          }
+        } )();
 
         const isLeftSide = $playerListCard.hasClass( 'PlayerListCard--left' );
 
@@ -394,4 +699,111 @@ export const showKdrMatch = () => {
 //     'verified': false
 //   },
 //   ttl: 1749963468500
-// } ];
+/**
+ * Injeta badge clicável de horas de CS2 nos jogadores do sidebar MyRoom
+ * (.LobbyPlayerHorizontal — a lista horizontal de jogadores na sala criada)
+ */
+export const showHoursMyRoom = () => {
+  const ATTR = 'data-gcb-hours-processed';
+
+  const processar = async $player => {
+    if ( !$player.length ) { return; }
+
+    // Evita processar duas vezes
+    if ( $player.attr( ATTR ) ) { return; }
+    $player.attr( ATTR, 'true' );
+
+    // Extrai playerId via [id^="player-trigger-wrapper-"] (igual ao autoKickNegativados)
+    const triggerEl = $player.find( '[id^="player-trigger-wrapper-"]' );
+    let playerId = null;
+    if ( triggerEl.length ) {
+      const match = triggerEl.attr( 'id' ).match( /player-trigger-wrapper-(\d+)/ );
+      playerId = match?.[1] || null;
+    }
+
+    // Fallback: extrai do href do nickname
+    if ( !playerId ) {
+      const href = $player.find( 'a[href*="/jogador/"]' ).attr( 'href' );
+      playerId = href?.split( '/' ).pop() || null;
+    }
+
+    if ( !playerId ) { return; }
+
+    // Pega o elemento nativo de KDR para ancoragem e valor
+    const $kdrNativo = $player.find( '.LobbyPlayerHorizontal__kdr' );
+    if ( !$kdrNativo.length ) { return; }
+
+    const kdrRaw = $kdrNativo.text().replace( /KDR/gi, '' ).trim();
+    const kdrNum = parseFloat( kdrRaw ) || 0;
+    const kdrText = isNaN( kdrNum ) ? '0.00' : kdrNum.toFixed( 2 );
+
+    const colorDefault = 'linear-gradient(135deg, rgba(0,255,222,0.8) 0%, rgba(245,255,0,0.8) 30%, rgba(255,145,0,1) 60%, rgba(166,0,255,0.8) 100%)';
+    const bg = kdrNum <= 2 ? ( levelColor[Math.round( kdrNum * 10 )] || '#555' ) + 'cc' : colorDefault;
+
+    // Cria a badge
+    const $badge = $( '<div/>', {
+      id: `gcb-hours-badge-${playerId}`,
+      class: 'gcb-myroom-hours-badge',
+      'data-kdr': kdrText,
+      'data-state': 'kdr',
+      title: '[GC Booster]: Clique para ver horas de CS2',
+      css: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: bg,
+        color: '#fff',
+        fontWeight: '700',
+        fontSize: '11px',
+        padding: '1px 6px',
+        borderRadius: '3px',
+        cursor: 'pointer',
+        marginLeft: '4px',
+        minWidth: '34px',
+        height: '18px',
+        userSelect: 'none',
+        flexShrink: 0
+      }
+    } ).text( kdrText );
+
+    // Toggle KDR ↔ Horas ao clicar
+    $badge.on( 'click', function ( e ) {
+      e.preventDefault();
+      e.stopPropagation();
+      const state = $( this ).attr( 'data-state' ) || 'kdr';
+      if ( state === 'kdr' ) {
+        $( this ).text( $( this ).attr( 'data-hours' ) || '...' );
+        $( this ).attr( 'data-state', 'hours' );
+      } else {
+        $( this ).text( $( this ).attr( 'data-kdr' ) );
+        $( this ).attr( 'data-state', 'kdr' );
+      }
+    } );
+
+    // Insere a badge imediatamente após o KDR nativo
+    $kdrNativo.after( $badge );
+
+    // Busca as horas de CS2 em background
+    ( async () => {
+      if ( !checkContext() ) { return; }
+      const hours = await fetchCS2Hours( playerId );
+      const formatted = formatHours( hours );
+      $badge.attr( 'data-hours', formatted || 'N/A' );
+    } )();
+  };
+
+  const scan = () => {
+    $( '.LobbyPlayerHorizontal' ).each( ( _, el ) => processar( $( el ) ) );
+  };
+
+  // Observer para pegar jogadores que entram na sala depois
+  const observer = new MutationObserver( () => {
+    if ( !checkContext() ) { observer.disconnect(); return; }
+    scan();
+  } );
+
+  observer.observe( document.body, { childList: true, subtree: true } );
+  scan(); // processa jogadores já presentes
+};
+
+

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -68,7 +68,8 @@ export const features = [
   'autoKickNegativados',
   'autoCopyLobbyLink',
   'showStats',
-  'filtrarKdrMedioLobby'
+  'filtrarKdrMedioLobby',
+  'steamHours'
 ];
 export const preVetosMapas = [
   {

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,11 +1,27 @@
 export const getFromStorage = async ( key, from = 'local' ) => {
   return new Promise( ( resolve, _reject ) => {
-    chrome.storage[from].get( key, resolve );
+    if ( typeof chrome === 'undefined' || !chrome.storage || !chrome.storage[from] ) {
+      resolve( {} );
+      return;
+    }
+    try {
+      chrome.storage[from].get( key, resolve );
+    } catch ( _e ) {
+      resolve( {} );
+    }
   } ).then( result => {
     if ( !key ) { return result; } else { return result[key]; }
   } );
 };
 
 export const setStorage = async ( key, value, from = 'local' ) => {
-  chrome.storage[from].set( { [key]: value } );
+  if ( typeof chrome === 'undefined' || !chrome.storage || !chrome.storage[from] ) {
+    return;
+  }
+  try {
+    chrome.storage[from].set( { [key]: value } );
+  } catch ( _e ) {
+    // console.warn('Could not save to storage', _e);
+  }
 };
+

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -274,6 +274,11 @@
         <input type="checkbox" id="showStats" />
         <span class="checkmark"></span>
       </label>
+      <label class="container" for="steamHours" title="Exibir horas de CS2 (Steam) junto ao KDR">
+        <p class="descricao" translation-key="show-steam-hours"></p>
+        <input type="checkbox" id="steamHours" />
+        <span class="checkmark"></span>
+      </label>
       <label class="container" for="disableShowPlayerSoloStats" title="Desativar estatísticas solo do jogador na Lobby">
         <p class="descricao" translation-key="disable-show-player-solo-stats"></p>
         <input type="checkbox" id="disableShowPlayerSoloStats" />
@@ -650,6 +655,20 @@
               <span class="checkmark"></span>
             </label>
           </div>
+        </div>
+      </div>
+      <hr />
+      <div>
+        <h3 class="subtitulo">Steam</h3>
+        <div class="form-input">
+          <span translation-key="steam-api-key-label">Chave da Web API do Steam (API Key)</span>
+          <div class="input-container">
+            <input type="text" id="steamApiKey" placeholder="Cole aqui sua Steam API Key de 32 caracteres" class="input-form-gray form-control" />
+          </div>
+          <p class="descricao" style="font-size: 11px; margin-top: 6px;" translation-key="steam-api-key-desc">
+            * Necessária para consultar as horas de jogo dos players na Steam. Obtenha a sua em
+            <a href="https://steamcommunity.com/dev/apikey" target="_blank" rel="noopener noreferrer" style="color: #00bcd4;">https://steamcommunity.com/dev/apikey</a>.
+          </p>
         </div>
       </div>
     </div>

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -54,6 +54,7 @@ function iniciarPaginaOpcoes() {
   atualizarValorWarmupSoundTime();
   adicionarListenersSons();
   loadWebhook();
+  loadSteamApiKey();
   adicionarListenerTraducao();
   listenerButtonBackup();
   listenerJogarCom();
@@ -444,6 +445,20 @@ function abrirPagina( pagina ) {
 
   link.classList.add( 'active' );
   paginaAtiva.classList.add( 'ativo' );
+}
+
+function loadSteamApiKey() {
+  chrome.storage.sync.get( [ 'steamApiKey' ], function ( data ) {
+    if ( data.steamApiKey ) {
+      document.getElementById( 'steamApiKey' ).value = data.steamApiKey;
+    } else {
+      document.getElementById( 'steamApiKey' ).value = '';
+    }
+  } );
+
+  document.getElementById( 'steamApiKey' ).addEventListener( 'change', function () {
+    chrome.storage.sync.set( { steamApiKey: this.value } );
+  } );
 }
 
 //Discord

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -101,5 +101,8 @@
   "filter-lobby-by-average-kdr": "Filter lobbies by average KDR",
   "show-stats": "Show player stats in the Lobby",
   "disable-show-map-stats-suggestions": "Disable map stats suggestions in the Lobby",
-  "disable-show-player-solo-stats": "Disable solo player stats in the Lobby"
+  "disable-show-player-solo-stats": "Disable solo player stats in the Lobby",
+  "show-steam-hours": "Show CS2 hours (Steam) next to KDR",
+  "steam-api-key-label": "Steam Web API Key",
+  "steam-api-key-desc": "* Required to check player hours on Steam. Get yours at <a href=\"https://steamcommunity.com/dev/apikey\" target=\"_blank\" rel=\"noopener noreferrer\" style=\"color: #00bcd4;\">https://steamcommunity.com/dev/apikey</a>."
 }

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -101,5 +101,8 @@
   "filter-lobby-by-average-kdr": "Filtrar lobbies por KDR promedio",
   "show-stats": "Mostrar estadísticas del jugador en el Lobby",
   "disable-show-map-stats-suggestions": "Desactivar sugerencias de estadísticas de mapas en el Lobby",
-  "disable-show-player-solo-stats": "Desactivar estadísticas solo del jugador en el Lobby"
+  "disable-show-player-solo-stats": "Desactivar estadísticas solo del jugador en el Lobby",
+  "show-steam-hours": "Mostrar horas de CS2 (Steam) junto al KDR",
+  "steam-api-key-label": "Clave de API web de Steam",
+  "steam-api-key-desc": "* Requerido para verificar las horas del jugador en Steam. Obtén la tuya en <a href=\"https://steamcommunity.com/dev/apikey\" target=\"_blank\" rel=\"noopener noreferrer\" style=\"color: #00bcd4;\">https://steamcommunity.com/dev/apikey</a>."
 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -101,5 +101,8 @@
   "filter-lobby-by-average-kdr": "Filtrer les lobbies par KDR moyen",
   "show-stats": "Afficher les statistiques du joueur dans le Lobby",
   "disable-show-map-stats-suggestions": "Désactiver les suggestions de statistiques de la carte dans le Lobby",
-  "disable-show-player-solo-stats": "Désactiver les statistiques solo du joueur dans le Lobby"
+  "disable-show-player-solo-stats": "Désactiver les statistiques solo du joueur dans le Lobby",
+  "show-steam-hours": "Afficher les heures CS2 (Steam) à côté de KDR",
+  "steam-api-key-label": "Clave API Web de Steam",
+  "steam-api-key-desc": "* Requis pour vérifier les heures des joueurs sur Steam. Obtenez le vôtre sur <a href=\"https://steamcommunity.com/dev/apikey\" target=\"_blank\" rel=\"noopener noreferrer\" style=\"color: #00bcd4;\">https://steamcommunity.com/dev/apikey</a>."
 }

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -102,5 +102,8 @@
   "filter-lobby-by-average-kdr": "Filtrar lobbies por KDR médio",
   "show-stats": "Exibir estatísticas do jogador na Lobby",
   "disable-show-map-stats-suggestions": "Desativar sugestões de estatísticas de mapas na Lobby",
-  "disable-show-player-solo-stats": "Desativar estatísticas solo do jogador na Lobby"
+  "disable-show-player-solo-stats": "Desativar estatísticas solo do jogador na Lobby",
+  "show-steam-hours": "Exibir horas de CS2 (Steam) junto ao KDR",
+  "steam-api-key-label": "Chave da Web API do Steam (API Key)",
+  "steam-api-key-desc": "* Necessária para consultar as horas de jogo dos players na Steam. Obtenha a sua em <a href=\"https://steamcommunity.com/dev/apikey\" target=\"_blank\" rel=\"noopener noreferrer\" style=\"color: #00bcd4;\">https://steamcommunity.com/dev/apikey</a>."
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
   mode: 'production',
   entry: {
     'index': resolveEntries( './src/options/*.js' ),
+    'background': './src/background/index.js',
     'content-scripts/main': contentScripts( 'main' ),
     'content-scripts/lobby': contentScripts( 'lobby' ),
     'content-scripts/missions': contentScripts( 'missions' ),

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -10,6 +10,7 @@ module.exports = {
   mode: 'development',
   entry: {
     'index': resolveEntries( './src/options/*.js' ),
+    'background': './src/background/index.js',
     'content-scripts/main': contentScripts( 'main' ),
     'content-scripts/lobby': contentScripts( 'lobby' ),
     'content-scripts/missions': contentScripts( 'missions' ),


### PR DESCRIPTION
Esta PR adiciona a funcionalidade de exibir as horas de jogo de CS2 (Steam) dos jogadores diretamente no lobby e no sidebar da sala criada (MyRoom). Para ver as horas, basta clicar na badge de KDR do respectivo jogador (um segundo clique alterna de volta para o KDR).

### 💡 Motivação e Contexto (Por que essa feature é importante?)

No cenário competitivo da GamersClub, é muito comum encontrar contas "smurfs" (jogadores de nível muito alto jogando em níveis baixos) ou contas recém-criadas que podem levantar suspeitas de uso de trapaça (cheaters). 

Embora ver o KDR médio do jogador ajude, ter acesso rápido às **horas de jogo na Steam** é o fator definitivo para tomar uma decisão rápida na lobby (como dar kick em alguém ou evitar aceitar um desafio suspeito):
- **Identificação de Smurfs/Cheaters:** Contas com KDR altíssimo e pouquíssimas horas de jogo (ex: 50h, 100h) são facilmente identificadas como suspeitas.
- **Praticidade:** Evita a necessidade de abrir o perfil da GC e depois a Steam de cada jogador manualmente para checar a legitimidade da conta.

---

### 🛠️ O que foi feito?

1. **Opções na Extensão:**
   - Adicionada a flag de controle `steamHours` nas configurações (com suporte a traduções em PT, EN, ES, FR).
   - Adicionado campo seguro para o usuário configurar sua própria **Steam Web API Key** (necessária para consultar a API oficial da Valve de forma confiável).

2. **Integração de APIs e Resolução de CORS:**
   - **Busca de Steam ID:** Desenvolvido scraper no HTML de perfil público (`/jogador/{playerId}`) que lê o link da Steam Community de forma assíncrona.
   - **Background Worker:** Criada a chamada de API da Steam através de um script de background (`src/background/index.js`) para contornar problemas de bloqueio de CORS que ocorrem diretamente no content script.
   - **Endpoint da Valve:** Consome o método `IPlayerService/GetOwnedGames/v1` buscando especificamente o ID `730` (CS2).

3. **Performance e Cache:**
   - Para evitar exceder o limite diário da API da Steam e otimizar requisições do usuário:
     - Os **Steam IDs** mapeados dos jogadores ficam salvos localmente por **7 dias**.
     - As **Horas de CS2** ficam em cache por **24 horas** no `chrome.storage.local`.

4. **Interface (UI):**
   - Implementado o toggle clicável no lobby principal.
   - Implementada a badge clicável no sidebar MyRoom (`.LobbyPlayerHorizontal`) ao lado do KDR nativo da GC.
