### PR TITLE
feat: adicionado alerta de jogadores com anotação negativa (alerta explicito)

### DIFF
--- a/src/content-scripts/content.css
+++ b/src/content-scripts/content.css
@@ -1014,3 +1014,32 @@ input[type="range"].filterKdr::-ms-track {
   border: 2px solid var(--color-white);
   background: var(--color-white);
 }
+
+/* Indicador individual no jogador reportado no lineup */
+.gcbooster-player-reported {
+  position: relative;
+  outline: 2px solid var(--color-dark-red-border) !important;
+  outline-offset: -2px;
+}
+
+.gcbooster-player-report-indicator {
+  position: absolute;
+  bottom: -2px;
+  right: -2px;
+  z-index: 10;
+  background: var(--color-dark-gray);
+  border: 2px solid var(--color-dark-red-border);
+  border-radius: 50%;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: default;
+  box-shadow: 0 0 5px rgba(0,0,0,0.5);
+}
+
+.gcbooster-player-report-indicator svg {
+  width: 12px;
+  height: 12px;
+}

--- a/src/content-scripts/lobby/getPlayerInfo.js
+++ b/src/content-scripts/lobby/getPlayerInfo.js
@@ -20,84 +20,124 @@ const limparCache = async () => {
 };
 
 const getAnotacao = html => {
-  if ( $( html ).find( '.gc-button-notes-negative' )[0] ) {
+  const $html = $( html );
+  if ( $html.find( '.gc-button-notes-negative, .PlayerAnnotations--negative, svg[stroke="#ff3b3b"], .note-negative' ).length ) {
     return 'Negativa';
   }
-  if ( $( html ).find( '.gc-button-notes-positive' )[0] ) {
+  if ( $html.find( '.gc-button-notes-positive' ).length ) {
     return 'Positiva';
   }
   return 'Nenhuma';
 };
 
-export async function getPlayerInfo( id ) {
+const requestQueue = [];
+let isProcessingQueue = false;
+
+const processQueue = async () => {
+  if ( isProcessingQueue || requestQueue.length === 0 ) { return; }
+  isProcessingQueue = true;
+
+  while ( requestQueue.length > 0 ) {
+    const task = requestQueue.shift();
+    await fetchPlayerInfoTask( task.id, task.resolve, task.reject );
+    // Delay de 1500ms entre as requisições para evitar rate limit (429)
+    await new Promise( resolve => setTimeout( resolve, 1500 ) );
+  }
+
+  isProcessingQueue = false;
+};
+
+const fetchPlayerInfoTask = async ( id, resolve, reject ) => {
+  try {
+    const url = `${BASE_URL}/${id}`;
+
+    await new Promise( ( res, rej ) => {
+      $.get( url, async function ( html ) {
+        try {
+          const $html = $( html );
+
+          const dataCriacaoElement = $html.find( SELETOR_DATA_CRIACAO ).filter( function () {
+            const text = $( this ).text().trim().toLowerCase();
+            return /(registrado\s*(em|el)|registered\s*in)/i.test( text );
+          } ).first();
+
+          const dataCriacao = dataCriacaoElement.next().text().trim();
+          const firstTab = $html.find( '#cs2-history-list' ).first();
+
+          let totalPartidas = 0;
+          let totalVitorias = 0;
+          let totalDerrotas = 0;
+
+          firstTab.find( '.gc-card-history-text' ).each( function () {
+            const text = $( this ).clone().children().remove().end().text().trim();
+            const qtd = parseInt( text.replace( /\D/g, '' ), 10 );
+            if ( !isNaN( qtd ) ) { totalPartidas += qtd; }
+          } );
+
+          firstTab.find( '.gc-card-history-detail span' ).each( function () {
+            const txt = $( this ).text().trim().toLowerCase();
+
+            if ( /vit[óo]ri(a|as)|victor(y|ies|ias)/i.test( txt ) ) {
+              const qtd = parseInt( txt.replace( /\D/g, '' ), 10 );
+              if ( !isNaN( qtd ) ) { totalVitorias += qtd; }
+            }
+
+            if ( /derrotas?|defeat(s)?/i.test( txt ) ) {
+              const qtd = parseInt( txt.replace( /\D/g, '' ), 10 );
+              if ( !isNaN( qtd ) ) { totalDerrotas += qtd; }
+            }
+          } );
+
+          const totalJogos = totalVitorias + totalDerrotas;
+          const porcentagemVitoria =
+            totalJogos > 0 ? ( ( totalVitorias / totalJogos ) * 100 ).toFixed( 2 ) : '0.00';
+
+          const anotacao = getAnotacao( html );
+
+          const response = {
+            dataCriacao,
+            totalPartidas,
+            porcentagemVitoria,
+            anotacao,
+            ttl: Date.now() + DOIS_DIAS
+          };
+
+          const lupaCache = await getFromStorage( 'lupaCache' ) || {};
+          lupaCache[id] = response;
+          await setStorage( 'lupaCache', lupaCache );
+          resolve( response );
+          res();
+        } catch ( err ) {
+          rej( err );
+        }
+      } ).fail( function ( jqXHR, textStatus, errorThrown ) {
+        reject( new Error( `Failed to load player ${id}: ${textStatus} ${errorThrown}` ) );
+        res(); // Resolve the inner promise so the queue continues even on failure
+      } );
+    } );
+  } catch ( e ) {
+    reject( e );
+  }
+};
+
+export async function getPlayerInfo( id, bypassQueue = false ) {
   const ultimaLimpezaCache = await getFromStorage( 'ultimaLimpezaCache' );
   if ( !ultimaLimpezaCache || ultimaLimpezaCache < Date.now() - DOIS_DIAS ) {
     await limparCache();
   }
   const lupaCache = await getFromStorage( 'lupaCache' ) || {};
-  if ( lupaCache?.[id]?.ttl > Date.now() ) {
+  if ( !bypassQueue && lupaCache?.[id]?.ttl > Date.now() ) {
     return lupaCache[id];
   }
-  const promise = new Promise( ( resolve, reject ) => {
-    try {
-      const url = `${BASE_URL}/${id}`;
 
-      $.get( url, function ( html ) {
-        const $html = $( html );
+  if ( bypassQueue ) {
+    return new Promise( ( resolve, reject ) => {
+      fetchPlayerInfoTask( id, resolve, reject );
+    } );
+  }
 
-        const dataCriacaoElement = $html.find( SELETOR_DATA_CRIACAO ).filter( function () {
-          const text = $( this ).text().trim().toLowerCase();
-          return /(registrado\s*(em|el)|registered\s*in)/i.test( text );
-        } ).first();
-
-        const dataCriacao = dataCriacaoElement.next().text().trim();
-        const firstTab = $html.find( '#cs2-history-list' ).first();
-
-        let totalPartidas = 0;
-        let totalVitorias = 0;
-        let totalDerrotas = 0;
-
-        firstTab.find( '.gc-card-history-text' ).each( function () {
-          const text = $( this ).clone().children().remove().end().text().trim();
-          const qtd = parseInt( text.replace( /\D/g, '' ), 10 );
-          if ( !isNaN( qtd ) ) { totalPartidas += qtd; }
-        } );
-
-        firstTab.find( '.gc-card-history-detail span' ).each( function () {
-          const txt = $( this ).text().trim().toLowerCase();
-
-          if ( /vit[óo]ri(a|as)|victor(y|ies|ias)/i.test( txt ) ) {
-            const qtd = parseInt( txt.replace( /\D/g, '' ), 10 );
-            if ( !isNaN( qtd ) ) { totalVitorias += qtd; }
-          }
-
-          if ( /derrotas?|defeat(s)?/i.test( txt ) ) {
-            const qtd = parseInt( txt.replace( /\D/g, '' ), 10 );
-            if ( !isNaN( qtd ) ) { totalDerrotas += qtd; }
-          }
-        } );
-
-        const totalJogos = totalVitorias + totalDerrotas;
-        const porcentagemVitoria =
-    totalJogos > 0 ? ( ( totalVitorias / totalJogos ) * 100 ).toFixed( 2 ) : '0.00';
-
-        const anotacao = getAnotacao( html );
-        const response = {
-          dataCriacao,
-          totalPartidas,
-          porcentagemVitoria,
-          anotacao,
-          ttl: Date.now() + DOIS_DIAS
-        };
-
-        lupaCache[id] = response;
-        setStorage( 'lupaCache', lupaCache );
-        resolve( response );
-      } );
-    } catch ( e ) {
-      reject( e );
-    }
+  return new Promise( ( resolve, reject ) => {
+    requestQueue.push( { id, resolve, reject } );
+    processQueue();
   } );
-
-  return promise;
 }

--- a/src/content-scripts/lobby/index.js
+++ b/src/content-scripts/lobby/index.js
@@ -19,6 +19,7 @@ import { ocultarSugestaoDeLobbies } from './ocultarSugestaoDeLobbies';
 import { showStats } from './showStats';
 import { lobbyMapSuggestions } from './lobbyMapSuggestions';
 import { showPlayerSoloStats } from './showPlayerSoloStats';
+import { mostrarReportDesafios, mostrarReportDesafiosInit } from './mostrarReportDesafios';
 
 chrome.storage.sync.get( null, function ( _result ) {
   if ( window.location.pathname.includes( 'partida' ) || window.location.pathname.includes( '/match/' ) ) {
@@ -45,6 +46,8 @@ const initLobby = async () => {
   criarObserver( '#lobbies-wrapper', mostrarKdr );
   criarObserver( '#lobbies-wrapper', infoLobby );
   criarObserver( '.lobby', infoChallenge );
+  criarObserver( '.lobby', mostrarReportDesafios );
+  criarObserver( '#lobbies-wrapper', mostrarReportDesafios );
   criarObserver( '#GamersClubCSApp-globals-globalToaster', tocarSomSeVoceForExpulsoDaLobby );
 
 
@@ -82,6 +85,8 @@ const initLobby = async () => {
   showStats();
   lobbyMapSuggestions();
   showPlayerSoloStats();
+  // Feature para mostrar jogadores reportados nos desafios
+  mostrarReportDesafiosInit();
   showKdrMatch();
   adicionarFiltroKdr();
 };

--- a/src/content-scripts/lobby/infoLobby.js
+++ b/src/content-scripts/lobby/infoLobby.js
@@ -140,11 +140,16 @@ const createModalForElementNew = ( element, getPlayersIdsFunction, type, lobbyId
         $( `#infos_lobby_${lobbyId}` ).append( loadingDiv );
       } );
 
-      for ( const player of players ) {
-        const response = await getPlayerInfo( player );
-        $( `#loading-${player}` ).replaceWith( createDivPlayers( response ) );
+      try {
+        for ( const player of players ) {
+          const response = await getPlayerInfo( player, true );
+          $( `#loading-${player}` ).replaceWith( createDivPlayers( response ) );
+        }
+      } catch ( _err ) {
+        // do nothing
+      } finally {
+        $.each( $( '.gcbooster_lupa' ), ( _, lupa ) => { lupa.style = 'display: flex'; } );
       }
-      $.each( $( '.gcbooster_lupa' ), ( _, lupa ) => { lupa.style = 'display: flex'; } );
     } );
     element.append( div );
   }
@@ -164,10 +169,10 @@ export const infoChallenge = mutations => {
 export const infoLobby = mutations => {
   $.each( mutations, ( _, mutation ) => {
     $( mutation.addedNodes )
-      .find( '.RoomCardWrapper' )
-      .addBack( '.RoomCardWrapper' )
+      .find( '.RoomCardWrapper, .LobbyRoom' )
+      .addBack( '.RoomCardWrapper, .LobbyRoom' )
       .each( ( _, element ) => {
-        const lobbyId = $( element ).attr( 'id' );
+        const lobbyId = $( element ).attr( 'id' ) || Math.random().toString( 36 ).substr( 2, 9 );
         createModalForElementNew( $( element ), getPlayersIdsNew, 'lobby', lobbyId );
       } );
   } );

--- a/src/content-scripts/lobby/mostrarReportDesafios.js
+++ b/src/content-scripts/lobby/mostrarReportDesafios.js
@@ -1,0 +1,79 @@
+import { getPlayerInfo } from './getPlayerInfo';
+
+const PLAYER_REPORT_CLASS = 'gcbooster-player-reported';
+const PROCESSED_ATTR = 'data-gcbooster-report-checked';
+
+let isFeatureEnabled = null;
+
+
+
+/**
+ * Marca visualmente um jogador individual como reportado no lineup.
+ */
+const marcarJogadorReportado = playerLink => {
+  if ( playerLink.classList.contains( PLAYER_REPORT_CLASS ) ) { return; }
+  playerLink.classList.add( PLAYER_REPORT_CLASS );
+
+  // Garante que o elemento pai tenha position relative para o indicator absoluto
+  if ( window.getComputedStyle( playerLink ).position === 'static' ) {
+    playerLink.style.position = 'relative';
+  }
+
+  const indicator = document.createElement( 'div' );
+  indicator.className = 'gcbooster-player-report-indicator';
+  indicator.title = 'Anotação negativa';
+  indicator.setAttribute( 'data-tip-text', 'Anotação negativa' );
+  // Ícone de anotação negativa (documento com ponta dobrada)
+  indicator.innerHTML = `
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#ff3b3b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 4h16v11l-5 5H4V4z"></path>
+      <path d="M15 15v5h5"></path>
+    </svg>
+  `;
+  playerLink.prepend( indicator );
+};
+
+const processarJogador = async playerLink => {
+  if ( playerLink.getAttribute( PROCESSED_ATTR ) ) { return; }
+  playerLink.setAttribute( PROCESSED_ATTR, 'processing' );
+
+  const match = playerLink.href.match( /\/player\/(\d+)/i );
+  const playerId = match ? match[1] : playerLink.href.split( '/' ).filter( Boolean ).pop();
+  if ( !playerId || isNaN( playerId ) ) {
+    playerLink.removeAttribute( PROCESSED_ATTR );
+    return;
+  }
+
+  try {
+    const info = await getPlayerInfo( playerId );
+    if ( info && info.anotacao === 'Negativa' ) {
+      marcarJogadorReportado( playerLink );
+    }
+  } catch ( _e ) {
+    // do nothing
+  }
+
+  playerLink.setAttribute( PROCESSED_ATTR, 'true' );
+};
+
+/**
+ * Observer para detectar cards de jogadores na DOM.
+ */
+export const mostrarReportDesafios = mutations => {
+  if ( isFeatureEnabled === false ) { return; }
+
+  $.each( mutations, ( _, mutation ) => {
+    $( mutation.addedNodes )
+      .find( 'a.LobbyPlayerVertical, .sala-lineup-imagem a' )
+      .addBack( 'a.LobbyPlayerVertical, .sala-lineup-imagem a' )
+      .each( ( _, element ) => {
+        processarJogador( element );
+      } );
+  } );
+};
+
+export const mostrarReportDesafiosInit = () => {
+  chrome.storage.sync.get( [ 'mostrarReportDesafios' ], result => {
+    isFeatureEnabled = result.mostrarReportDesafios !== false; // Default to true or let user toggle it
+  } );
+};

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -68,7 +68,8 @@ export const features = [
   'autoKickNegativados',
   'autoCopyLobbyLink',
   'showStats',
-  'filtrarKdrMedioLobby'
+  'filtrarKdrMedioLobby',
+  'mostrarReportDesafios'
 ];
 export const preVetosMapas = [
   {

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -210,6 +210,12 @@
         <input type="checkbox" id="autoKickNegativados" />
         <span class="checkmark"></span>
       </label>
+      <label class="container" for="mostrarReportDesafios" title="Mostrar jogadores reportados nos desafios">
+        <p class="descricao" translation-key="mostrar-report-desafios"></p>
+        <input type="checkbox" id="mostrarReportDesafios" />
+        <span class="checkmark"></span>
+      </label>
+
       <br />
       <h3 class="subtitulo" translation-key="melhorias"></h3>
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -101,5 +101,7 @@
   "filter-lobby-by-average-kdr": "Filter lobbies by average KDR",
   "show-stats": "Show player stats in the Lobby",
   "disable-show-map-stats-suggestions": "Disable map stats suggestions in the Lobby",
-  "disable-show-player-solo-stats": "Disable solo player stats in the Lobby"
+  "disable-show-player-solo-stats": "Disable solo player stats in the Lobby",
+  "mostrar-report-desafios": "Show reported players in challenges",
+  "mostrar-anotacoes-lobby": "Show negative annotations of players in your lobby"
 }

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -101,5 +101,7 @@
   "filter-lobby-by-average-kdr": "Filtrar lobbies por KDR promedio",
   "show-stats": "Mostrar estadísticas del jugador en el Lobby",
   "disable-show-map-stats-suggestions": "Desactivar sugerencias de estadísticas de mapas en el Lobby",
-  "disable-show-player-solo-stats": "Desactivar estadísticas solo del jugador en el Lobby"
+  "disable-show-player-solo-stats": "Desactivar estadísticas solo del jugador en el Lobby",
+  "mostrar-report-desafios": "Mostrar jugadores reportados en los desafíos",
+  "mostrar-anotacoes-lobby": "Mostrar anotaciones negativas de los jugadores en su lobby"
 }

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -102,5 +102,7 @@
   "filter-lobby-by-average-kdr": "Filtrar lobbies por KDR médio",
   "show-stats": "Exibir estatísticas do jogador na Lobby",
   "disable-show-map-stats-suggestions": "Desativar sugestões de estatísticas de mapas na Lobby",
-  "disable-show-player-solo-stats": "Desativar estatísticas solo do jogador na Lobby"
+  "disable-show-player-solo-stats": "Desativar estatísticas solo do jogador na Lobby",
+  "mostrar-report-desafios": "Mostrar jogadores reportados nos desafios",
+  "mostrar-anotacoes-lobby": "Mostrar anotações negativas dos jogadores na sua sala"
 }


### PR DESCRIPTION
Este PR torna a visualização de Anotações Negativas muito mais explícita e rápida na interface de seleção de lobbies.

Antes, era necessário que o jogador clicasse ativamente na "Lupa" de cada time para descobrir se havia alguém com anotação
 ("A: 👎"). Agora, a funcionalidade foi puxada para a tela principal: a extensão varre automaticamente os jogadores das salas e adiciona um contorno vermelho chamativo e um ícone de alerta direto no avatar de quem possui anotação negativa.

Dessa forma, o usuário bate o olho na tela e já consegue identificar e evitar jogadores indesejados sem precisar dar um clique sequer.

Detalhes Técnicos e Otimizações:
Verificação Automática: Implementado um observer que verifica o lineup das salas e marca visualmente os jogadores com anotações negativas.
Performance: O recurso se aproveita do cache de 2 dias do getPlayerInfo para não dar spam de requisições na GC ao carregar a tela. Os carregamentos iniciais têm delay de segurança de 1.5s/jogador, mas ficam instantâneos após entrarem no cache.
Refresh Manual (Force Update): A Lupa agora atua como um botão de "Atualizar". Clicar nela faz com que o bypassQueue ignore o cache e busque os dados fresquinhos do servidor. Perfeito para quando o jogador acabou de anotar alguém e quer ver refletido na tela.